### PR TITLE
Improved TableMgr for bulk operations

### DIFF
--- a/lib/describe.sql
+++ b/lib/describe.sql
@@ -39,6 +39,8 @@ FROM INFORMATION_SCHEMA.TABLES st
   LEFT OUTER JOIN
   sys.indexes i ON ic.object_id = i.object_id AND ic.index_id = i.index_id
 WHERE
-  c.object_id = OBJECT_ID('<table_name>')
+  c.object_id = OBJECT_ID('<escaped_table_name>')
   AND TABLE_TYPE = 'BASE TABLE'
   AND sc.TABLE_NAME = '<table_name>'
+  AND (sc.TABLE_SCHEMA = '<table_schema>' or '<table_schema>' = '')
+  

--- a/lib/tableMgr.js
+++ b/lib/tableMgr.js
@@ -46,7 +46,13 @@ function TableMgr(c) {
         readFile(folder + '/describe.sql', done);
 
         function done(data) {
-            sql = data.replace(/<table_name>/g, tableName);
+            var tableParts = tableName.split(/\.(?![^\[]*\])/g); //Split table names like 'dbo.table1' to: ['dbo', 'table1'] and 'table1' to: ['table1']
+            var table = tableParts[tableParts.length - 1]; //get the table name
+            var schema = tableParts[tableParts.length - 2] || ''; //get the table schema, if missing set schema to '' 
+            sql = data.replace(/<table_name>/g, table.replace(/^\[|\]$/g, '').replace(/\]\]/g, ']')) //removes brackets at start end end, change ']]' to ']'
+                    .replace(/<table_schema>/g, schema.replace(/^\[|\]$/g, '').replace(/\]\]/g, ']')) //removes brackets at start end end, change ']]' to ']'
+                    .replace(/<escaped_table_name>/g, table); // use the escaped table name for the OBJECT_ID() function
+            
             conn.query(sql, function (err, results) {
                 callback(err, results);
             });


### PR DESCRIPTION
Add supports for table names wrapped in brackets, different table
schemas, escaped table or schema names.

related to #6 

unfortunately I can not run the test. I still stuck on SQL Server 2005 ... and therefore no 'hierarchyid'.

I've tested the following table names:
* bulk_table
* dbo.bulk_table
* dbo.[bulk table]
* [dbo].[bulk table]
* [EXAMPLE.COM\\Simpson].bulk_table
* dbo.[don't [do]] that] 