### PR TITLE
Normalize binaryDir path

### DIFF
--- a/lib/sqlserver.native.js
+++ b/lib/sqlserver.native.js
@@ -36,7 +36,8 @@ function debugLoad() {
 }
 
 function liveLoad() {
-    var binaryDir= __dirname + '/bin/';
+    var path = require('path');
+    var binaryDir = path.join(__dirname, 'bin');
     //noinspection JSUnresolvedFunction
     var files = require('fs').readdirSync(binaryDir);
 
@@ -50,7 +51,7 @@ function liveLoad() {
 // If the require fails, we can just ignore the exception and continue trying
     function attemptToExportBinary(filename) {
         try {
-            var native = binaryDir + filename;
+            var native = path.join(binaryDir, filename);
             module.exports = require(native);
         } catch (e) {
         }


### PR DESCRIPTION
I was having some trouble in an Electron app. (app content is inside a .asar archive - https://github.com/electron/asar)

When binaryDir ends with / or \\, readdirSync(binaryDir) returns .asar root files instead of binaryDir files.