### PR TITLE
Fix for table_desribe listing duplicate columns

### DIFF
--- a/lib/queries/table_describe.sql
+++ b/lib/queries/table_describe.sql
@@ -78,4 +78,5 @@ WHERE
   AND TABLE_TYPE = 'BASE TABLE'
   AND sc.TABLE_NAME = r.table_name
   AND (sc.TABLE_SCHEMA = '<table_schema>' or '<table_schema>' = '')
+  AND (ta.schema_id = SCHEMA_ID('<table_schema>') or '<table_schema>' = '')
   


### PR DESCRIPTION
If a table exists in multiple schemas, columns for tables in all of those schemas where listed by this query. This resulted in "RequestError: String data, right truncation" messages when running a bulk insert.