### PR TITLE
Improve the TypeScript build

### DIFF
--- a/tool/build-typescript-samples.bat
+++ b/tool/build-typescript-samples.bat
@@ -1,3 +1,8 @@
 @echo off
 echo Building TypeScript samples
-call npm run --prefix samples\typescript tsc
+cd samples\typescript
+
+CALL npm install
+CALL npm run tsc
+
+cd ..\..\

--- a/tool/build.bat
+++ b/tool/build.bat
@@ -2,8 +2,6 @@ set path=%path%;%~dp0
 @echo off
 copy bindingdotgyp.old binding.gyp
 call npm install -g node-gyp
-call npm install @types/node
-call npm install -g typescript
 call build_arch.bat node ia32
 call build_arch.bat node x64
 call build-typescript-samples.bat


### PR DESCRIPTION
As you figured out, the issue with the building TypeScript samples you hit over the weekend was the TypeScript compiler was not installed.

Instead of installing it globally, it's probably better to run `npm install` in the TypeScript samples and run the TypeScript compiler from there.