### PR TITLE
Add support for cypress

### DIFF
--- a/src/BoundDatum.cpp
+++ b/src/BoundDatum.cpp
@@ -199,7 +199,7 @@ namespace mssql
 			const auto maybe = p->ToString(context);
 			Local<String> str_param;
 			if (maybe.ToLocal(&str_param)) {
-				str_param->WriteUtf8(fact.isolate, _storage->charvec_ptr->data(), precision);
+				str_param->WriteUtf8(_storage->charvec_ptr->data(), precision);
 				_indvec[0] = precision;
 			}
 		}
@@ -271,7 +271,7 @@ namespace mssql
 					if (maybe_string.ToLocal(&str)) {
 						const auto width = str->Length() * size;
 						_indvec[i] = width;
-						str->Write(fact.isolate, &*itr, 0, max_str_len);
+						str->Write(&*itr, 0, max_str_len);
 					}
 				}
 			}
@@ -293,7 +293,7 @@ namespace mssql
 			Local<String> str_param;
 			if (maybe.ToLocal(&str_param)) {
 				const auto first_p = _storage->uint16vec_ptr->data();
-				str_param->Write(fact.isolate, first_p, 0, precision);
+				str_param->Write(first_p, 0, precision);
 				buffer_len = precision * size;
 				if (precision > 4000)
 				{
@@ -400,7 +400,7 @@ namespace mssql
 		wstring_convert<codecvt_utf8_utf16<wchar_t>> converter;
 		char tmp[1 * 1024];
 		const auto precision = min(1024, s->Length() + 1);
-		s->WriteUtf8(fact.isolate, tmp, precision);
+		s->WriteUtf8(tmp, precision);
 		const string narrow(tmp);
 		const auto wide = converter.from_bytes(narrow);
 		return wide;
@@ -428,7 +428,7 @@ namespace mssql
 		_storage->ReserveChars(precision + 1);
 		_storage->ReserveUint16(precision + 1);
 		auto* itr_p = _storage->charvec_ptr->data();
-		type_id_str->WriteUtf8(fact.isolate, itr_p, precision);
+		type_id_str->WriteUtf8(itr_p, precision);
 		const string narrow = _storage->charvec_ptr->data();
 		const auto wide = converter.from_bytes(narrow);
 		memcpy(static_cast<void*>(_storage->uint16vec_ptr->data()), wide.c_str(), precision * sizeof(uint16_t));
@@ -963,10 +963,10 @@ namespace mssql
 			if (!elem->IsNull())
 			{
 				_indvec[i] = 0;
-				const auto maybe = elem->ToBigInt(context);
-				Local<BigInt> local;
+				const auto maybe = elem->ToInt32(context);
+				Local<Int32> local;
 				if (maybe.ToLocal(&local)) {
-					vec[i] = local->Int64Value();
+					vec[i] = local->Int32Value();
 				}
 			}
 		}

--- a/src/BoundDatumHelper.h
+++ b/src/BoundDatumHelper.h
@@ -146,15 +146,6 @@ namespace mssql
 			else if (p->IsUint32()) {
 				++uint32Count;
 			}
-			else if (p->IsBigInt())
-			{
-				MaybeLocal<BigInt> maybe = p->ToBigInt(context);
-				Local<BigInt> local;
-				if (maybe.ToLocal(&local))
-				{
-					++int64Count;
-				}
-			}
 			else if (p->IsNumber()) {
 				MaybeLocal<Number> maybe = p->ToNumber(context);
 				Local<Number> local;

--- a/src/QueryOperationParams.h
+++ b/src/QueryOperationParams.h
@@ -58,11 +58,11 @@ namespace mssql
 			auto l = get(query_object, v);
 			if (!l->IsNull())
 			{
-				auto maybe = l->ToBigInt(context);
-				Local<BigInt> local;
+				auto maybe = l->ToInt32(context);
+				Local<Int32> local;
 				if (maybe.ToLocal(&local))
 				{
-					return local->Int64Value();
+					return local->Int32Value();
 				}
 			}
 			return 0;
@@ -74,11 +74,11 @@ namespace mssql
 			auto context = fact.isolate->GetCurrentContext();
 			if (!l->IsNull())
 			{
-				auto maybe = l->ToBigInt(context);
-				Local<BigInt> local;
+				auto maybe = l->ToInt32(context);
+				Local<Int32> local;
 				if (maybe.ToLocal(&local))
 				{
-					return local->Int64Value();
+					return local->Int32Value();
 				}
 			}
 			return 0;

--- a/src/Utility.cpp
+++ b/src/Utility.cpp
@@ -37,7 +37,7 @@ namespace mssql
 		while (read < length)
 		{
 			const auto toread = min(buffer_length, length - read);
-			const auto actual = input->Write(fact.isolate, buffer, read, toread);
+			const auto actual = input->Write(buffer, read, toread);
 			result.append(reinterpret_cast<const wchar_t*>(buffer), actual);
 			read += actual;
 		}


### PR DESCRIPTION
Hello

I would like to get this lib to work with [Cypress](https://www.cypress.io/). I have a build which works - I can run a SQL query and get results back.

I had to run node-gyp configure like this:
`node-gyp configure --target=v8.2.1`
since this is the version of node that Cypress targets.

Then I had to change the generated win_delay_load_hook.cc so that it would load functions from node.dll instead of Cypress.exe:

```c++
static FARPROC WINAPI load_exe_hook(unsigned int event, DelayLoadInfo* info) {
  HMODULE m;
  if (event != dliNotePreLoadLibrary)
    return NULL;

  if (_stricmp(info->szDll, "iojs.exe") != 0 &&
      _stricmp(info->szDll, "node.exe") != 0)
    return NULL;

  m = GetModuleHandle(L"node.dll");
  return (FARPROC) m;
}
```

Also, node 8.2.1 seems to lack support for BigInt so I changed this to Int32. The WriteUtf8 and Write API also seems to have changed, and I was able to get these to compile by removing the extra parameter. No idea what the impact of this change is though.

Is it possible to make these changes in a more robust way and upstream them so that we can use this module with Cypress?