### PR TITLE
Make sure pausing a query actually stops row events

### DIFF
--- a/unit.tests/pause.js
+++ b/unit.tests/pause.js
@@ -75,4 +75,21 @@ suite('pause', function () {
       testDone()
     })
   })
+
+  test('pause a large query to only get 100 rows', testDone => {
+    const q = theConnection.query(`select * from syscolumns`)
+    q.on('error', (e) => {
+      assert.ifError(e)
+    })
+    q.on('row', () => {
+      ++rows
+      if (rows % 100 === 0) {
+        q.pauseQuery()
+        setTimeout(() => {
+          assert.strictEqual(expected, rows)
+          testDone()
+        }, 200)
+      }
+    })
+  })
 })


### PR DESCRIPTION
I'm having trouble getting the `pauseQuery` feature to work as expected in my test suite (https://github.com/tediousjs/node-mssql/pull/877) - so I just wanted to write this test to see if it's consistent behaviour or not