### PR TITLE
Allow a query to be in an initially paused state

### DIFF
--- a/lib/notifier.js
+++ b/lib/notifier.js
@@ -18,6 +18,7 @@ const notifyModule = ((() => {
       let queryObj
       let queryWorker
       let operation
+      let paused
 
       function getQueryObj () {
         return queryObj
@@ -45,6 +46,9 @@ const notifyModule = ((() => {
 
       function setQueryWorker (qw) {
         queryWorker = qw
+        if (paused) {
+          queryWorker.pause()
+        }
       }
 
       function cancelQuery (cb) {
@@ -58,12 +62,14 @@ const notifyModule = ((() => {
       }
 
       function pauseQuery () {
+        paused = true
         if (queryWorker) {
           queryWorker.pause()
         }
       }
 
       function resumeQuery () {
+        paused = false
         if (queryWorker) {
           queryWorker.resume()
         }

--- a/unit.tests/pause.js
+++ b/unit.tests/pause.js
@@ -82,6 +82,23 @@ suite('pause', function () {
     })
   })
 
+  test('queries can start off paused', testDone => {
+    const q = theConnection.query(`select top 3000 * from syscolumns`)
+    q.pauseQuery()
+    let rows = 0
+    q.on('error', (e) => {
+      assert.ifError(e)
+    })
+    q.on('row', () => {
+      ++rows
+    })
+    setTimeout(() => {
+      // make sure no rows were received
+      assert.strictEqual(0, rows)
+      testDone()
+    }, 200)
+  })
+
   test('run a large query', testDone => {
     const q = theConnection.query(`select * from syscolumns`)
     q.on('error', (e) => {


### PR DESCRIPTION
See #98 for context.

This allows a query to be in an initially paused state