### PR TITLE
Support Webpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,19 @@ sql.query(connectionString, query, (err, rows) => {
 
 See our [TypeScript sample app](samples/typescript) for more details.
 
+### Webpack
+
+If you are using Webpack for your application, you need to:
+
+1. Add the [node-loader](https://webpack.js.org/loaders/node-loader/) as a dev dependency.
+2. Update your `webpack.config.js` to include the following under `module.rules`:
+    ```
+    {
+        test: /\.node$/,
+        use: 'node-loader'
+    }
+    ```
+
 ## Prepared Statements
 
 It is now possible to prepare one or more statements which can then be invoked

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -29,7 +29,7 @@ const bootModule = ((() => {
 
   function debugLoad () {
     const binaryDir = __dirname
-    const filename = '..\\build\\Debug\\    try { module.exports = require('./bin/sqlserverv8.node'
+    const filename = '..\\build\\Debug\\sqlserverv8.node'
     console.log('DEBUG mode filename ' + filename)
     const native = path.join(binaryDir, filename)
     console.log('DEBUG loading from native ' + native)

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -29,7 +29,7 @@ const bootModule = ((() => {
 
   function debugLoad () {
     const binaryDir = __dirname
-    const filename = '..\\build\\Debug\\sqlserverv8.node'
+    const filename = '..\\build\\Debug\\    try { module.exports = require('./bin/sqlserverv8.node'
     console.log('DEBUG mode filename ' + filename)
     const native = path.join(binaryDir, filename)
     console.log('DEBUG loading from native ' + native)
@@ -42,22 +42,24 @@ const bootModule = ((() => {
   }
 
   function liveLoad () {
-    files.forEach(file => {
-      if (noBinaryExported()) {
-        attemptToExportBinary(file)
-      }
-    })
-
-    failIfNoBinaryExported()
-
+    // Try loading the correct lib for this platform/environment 
     // If the require fails, we can just ignore the exception and continue trying
-    function attemptToExportBinary (filename) {
-      try {
-        const native = path.join(binaryDir, filename)
-        module.exports = require(native)
-      } catch (e) {
-      }
-    }
+    try { module.exports = require('./bin/sqlserverv8.node.v10.16.0.ia32.node'); } catch (e) {};    
+    try { module.exports = require('./bin/sqlserverv8.node.v10.16.0.x64.node'); } catch (e) {};
+    try { module.exports = require('./bin/sqlserverv8.node.v11.15.0.electron.v5.0.12.ia32.node'); } catch (e) {};
+    try { module.exports = require('./bin/sqlserverv8.node.v11.15.0.electron.v5.0.12.x64.node'); } catch (e) {};
+    try { module.exports = require('./bin/sqlserverv8.node.v11.15.0.ia32.node'); } catch (e) {};
+    try { module.exports = require('./bin/sqlserverv8.node.v11.15.0.x64.node'); } catch (e) {};
+    try { module.exports = require('./bin/sqlserverv8.node.v12.13.0.electron.v6.1.5.ia32.node'); } catch (e) {};
+    try { module.exports = require('./bin/sqlserverv8.node.v12.13.0.electron.v6.1.5.x64.node'); } catch (e) {};
+    try { module.exports = require('./bin/sqlserverv8.node.v12.13.0.electron.v7.1.2.ia32.node'); } catch (e) {};
+    try { module.exports = require('./bin/sqlserverv8.node.v12.13.0.electron.v7.1.2.x64.node'); } catch (e) {};
+    try { module.exports = require('./bin/sqlserverv8.node.v12.13.1.ia32.node'); } catch (e) {};
+    try { module.exports = require('./bin/sqlserverv8.node.v12.13.1.x64.node'); } catch (e) {};
+    try { module.exports = require('./bin/sqlserverv8.node.v13.2.0.ia32.node'); } catch (e) {};
+    try { module.exports = require('./bin/sqlserverv8.node.v13.2.0.x64.node'); } catch (e) {};
+
+    failIfNoBinaryExported();
 
     function failIfNoBinaryExported () {
       if (noBinaryExported()) {

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -23,11 +23,9 @@
 // ---------------------------------------------------------------------------------------------------------------------------------
 
 const bootModule = ((() => {
-  const path = require('path')
-  const binaryDir = path.join(__dirname, 'bin')
-  const files = require('fs').readdirSync(binaryDir)
-
+  
   function debugLoad () {
+    const path = require('path')
     const binaryDir = __dirname
     const filename = '..\\build\\Debug\\sqlserverv8.node'
     console.log('DEBUG mode filename ' + filename)


### PR DESCRIPTION
Fixes #127 - Supports projects that use Webpack.

### Current Issue
Webpack converts `require()` calls to [`__webpack_require__`](https://webpack.js.org/api/module-variables/#__webpack_require__-webpack-specific) statements and copies all dependencies into an output directory. The current `lib/bootstrap.js` script dynamically reads the list of available library versions and tries to load each one. Since Webpack does not know at processing time which files will be read from the `binaryDir`, it does not properly convert the `bootstrap.js` `require()` statement and copy the binaries to the output directory.

### Proposed Fix
Convert the dynamic reading of available `.node` binaries to hard-coded values. This is functionally the same, but will work correctly with Webpack. 

Unfortunately, this will add to the maintenance load and need to be updated every time new binaries are created.

### Note for Webpack Users
I still needed to copy the relevant `sqlserverv8.node.*.node` files to `outputFolder/bin/` for the binaries to be successfully loaded after running `webpack`.