### PR TITLE
chore - use SPDX identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "licenses": [
     {
-      "type": "Apache 2.0",
+      "type": "Apache-2.0",
       "url": "https://github.com/TimelordUK/node-sqlserver-v8/blob/master/LICENSE"
     }
   ],


### PR DESCRIPTION
As per https://docs.npmjs.com/files/package.json#license,

> If you’re using a common license such as BSD-2-Clause or MIT, add a current SPDX license identifier for the license you’re using...

Based on https://spdx.org/licenses/, Apache 2.0 license has a SPDX identifier of `Apache-2.0`.

This PR looks to correct the identifier used in package.json.