### PR TITLE
Adding Mac OS X support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ dist/
 # Prebuilds
 prebuilds/
 build/
+
+# Mac
+.DS_Store

--- a/binding.gyp
+++ b/binding.gyp
@@ -86,6 +86,22 @@
               '/opt/microsoft/msodbcsql17/include/',
             ],
         }],
+        ['OS=="mac"', {
+            'link_settings': {
+             'libraries': ['-L/usr/local/lib', '-lmsodbcsql.17'],
+            },
+            'defines': [
+              'LINUX_BUILD',
+              'UNICODE'
+            ], 
+            'cflags_cc': [
+              '-std=c++1y'
+            ],
+            'include_dirs': [
+              '/usr/local/include/',
+              '/usr/local/opt/msodbcsql17/include/',
+            ],
+        }],
       ]
     }
   ]

--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
   },
   "os": [
     "win32",
-    "linux"
+    "linux",
+    "darwin"
   ],
   "scripts": {
     "prebuild-gyp": "node-gyp rebuild",


### PR DESCRIPTION
Adding build settings to support building on Mac OS X. Tests can be run with the same settings as for Linux, but paths are different for external libraries.

msodbcsql17 installed using Homebrew as directed in the Microsoft documentation for.