### PR TITLE
fix: added check for null and undefined strings

### DIFF
--- a/src/BoundDatum.cpp
+++ b/src/BoundDatum.cpp
@@ -246,7 +246,13 @@ namespace mssql
 			_indvec[i] = SQL_NULL_DATA;
 			auto elem = Nan::Get(arr, i);
 			if (elem.IsEmpty()) continue;
-			auto maybe_value = Nan::To<String>(elem.ToLocalChecked());
+			auto local_elem = elem.ToLocalChecked();
+			if (local_elem->IsNull() || local_elem->IsUndefined())
+			{
+				itr += max_str_len;
+				continue;
+			}
+			auto maybe_value = Nan::To<String>(local_elem);
 			const auto str = maybe_value.FromMaybe(Nan::EmptyString()); 	
 			const auto width = str->Length() * size;
 			_indvec[i] = width;


### PR DESCRIPTION
I found a bug, where passing TVP with varchar column as parameter, filled with null values, leads to recording the data in SQL server, with "null", instead of NULL. This is caused because of the default behavior of V8, converting JavaScript values, to strings in C++, where null is converted into "null" and undefined is converted into "undefined".

This pull request is adding check for IsNull and IsUndefined on v8::Local<v8::Value> and fix this issue. If you need me, I can prepare an isolated environment, describing this behavior. 