### PR TITLE
Enhance errors to include severity, server name, procedure name and line number of the error

### DIFF
--- a/src/OdbcError.cpp
+++ b/src/OdbcError.cpp
@@ -24,5 +24,5 @@ namespace mssql {
 
 	// error returned when a string returns no data but it's not a NULL field
 	// ODBC returns SQL_NO_DATA so we translate this into an error and return it to node.js
-    OdbcError OdbcError::NODE_SQL_NO_DATA = OdbcError( "IMNOD", "No data returned", 1 );
+    OdbcError OdbcError::NODE_SQL_NO_DATA = OdbcError( "IMNOD", "No data returned", 1, 0, "", "", 0);
 }

--- a/src/OdbcError.h
+++ b/src/OdbcError.h
@@ -27,8 +27,11 @@ namespace mssql
     {
     public:
 
-        OdbcError( const char* sqlstate, const char* message, SQLINTEGER code )
-           : sqlstate( sqlstate ), message(message), code(code)
+        OdbcError( const char* sqlstate, const char* message, SQLINTEGER code, 
+                    const int severity, const char* serverName, const char* procName, const unsigned int lineNumber 
+        )
+           : sqlstate( sqlstate ), message(message), code(code), 
+                severity(severity), serverName(serverName), procName(procName), lineNumber(lineNumber)
         {
         }
 
@@ -46,6 +49,26 @@ namespace mssql
         {
             return code;
         }
+        
+        const int Severity( void ) const
+        {
+            return severity;
+        }
+
+        const char* ServerName( void ) const
+        {
+            return serverName.c_str();
+        }
+
+        const char* ProcName( void ) const
+        {
+            return procName.c_str();
+        }
+
+        const unsigned int LineNumber( void ) const
+        {
+            return lineNumber;
+        }
 
         // list of msnodesql specific errors
         static OdbcError NODE_SQL_NO_DATA;
@@ -54,6 +77,10 @@ namespace mssql
         string sqlstate;
         string message; 
         SQLINTEGER code;
+        int severity;
+        string serverName;
+        string procName;
+        unsigned int lineNumber;
     };
 
 }

--- a/src/OdbcOperation.cpp
+++ b/src/OdbcOperation.cpp
@@ -91,7 +91,7 @@ namespace mssql
 		if (!_failures || _failures->empty())
 		{
 			_failures = make_shared<vector<shared_ptr<OdbcError>>>();
-			_failures->push_back(make_shared<OdbcError>("unknown", "internal error", -1));
+			_failures->push_back(make_shared<OdbcError>("unknown", "internal error", -1, 0, "", "", 0));
 		}
 	}
 
@@ -106,6 +106,10 @@ namespace mssql
 			const auto err = fact.error(failure->Message());
 			Nan::Set(err, Nan::New("sqlstate").ToLocalChecked(), Nan::New(failure->SqlState()).ToLocalChecked());
 			Nan::Set(err, Nan::New("code").ToLocalChecked(), Nan::New(failure->Code()));
+			Nan::Set(err, Nan::New("severity").ToLocalChecked(), Nan::New(static_cast<int32_t>(failure->Severity())));
+			Nan::Set(err, Nan::New("serverName").ToLocalChecked(), Nan::New(failure->ServerName()).ToLocalChecked());
+			Nan::Set(err, Nan::New("procName").ToLocalChecked(), Nan::New(failure->ProcName()).ToLocalChecked());
+			Nan::Set(err, Nan::New("lineNumber").ToLocalChecked(), Nan::New(static_cast<uint32_t>(failure->LineNumber())));
 			Nan::Set(errors, i, err);
 		}
 		

--- a/src/OdbcStatement.cpp
+++ b/src/OdbcStatement.cpp
@@ -201,7 +201,7 @@ namespace mssql
 		SQLINTEGER native_error = -1;
 		const auto* c_state = "CANCEL";
 		const auto* c_msg = "Error: [msnodesql] cancel only supported for statements where polling is enabled.";
-		_errors->push_back(make_shared<OdbcError>(c_state, c_msg, native_error));
+		_errors->push_back(make_shared<OdbcError>(c_state, c_msg, native_error, 0, "", "", 0));
 		return false;
 	}
 
@@ -603,7 +603,7 @@ namespace mssql
 		_endOfResults = true; // reset
 		const string c_msg = "[Microsoft] Operation canceled";
 		const string c_state = "U00000";
-		const auto last = make_shared<OdbcError>(c_state.c_str(), c_msg.c_str(), 0);
+		const auto last = make_shared<OdbcError>(c_state.c_str(), c_msg.c_str(), 0, 0, "", "", 0);
 		_errors->push_back(last);
 		return true;
 	}

--- a/unit.tests/json.js
+++ b/unit.tests/json.js
@@ -1,7 +1,7 @@
 'use strict'
 /* global suite teardown teardown setup */
 
-const supp = require('msnodesqlv8/samples/typescript/demo-support')
+const supp = require('../samples/typescript/demo-support')
 const assert = require('assert')
 const util = require('util')
 const { test } = require('mocha')

--- a/unit.tests/query.js
+++ b/unit.tests/query.js
@@ -455,11 +455,16 @@ suite('query', function () {
     const expectedError = new Error('[Microsoft][' + driver + '][SQL Server]Unclosed quotation mark after the character string \'m with NOBODY\'.')
     expectedError.sqlstate = '42000'
     expectedError.code = 105
+    expectedError.severity = 15
+    expectedError.procName = ''
+    expectedError.lineNumber = 1
     const fns = [
       asyncDone => {
         assert.doesNotThrow(() => {
           theConnection.queryRaw('I\'m with NOBODY', e => {
             assert(e instanceof Error)
+            assert(e.serverName.length > 0)
+            delete e.serverName
             assert.deepStrictEqual(e, expectedError, 'Unexpected error returned')
             asyncDone()
           })
@@ -471,6 +476,8 @@ suite('query', function () {
           const s = theConnection.queryRaw('I\'m with NOBODY')
           s.on('error', e => {
             assert(e instanceof Error)
+            assert(e.serverName.length > 0)
+            delete e.serverName
             assert.deepStrictEqual(e, expectedError, 'Unexpected error returned')
             asyncDone()
           })
@@ -594,40 +601,6 @@ suite('query', function () {
       assert.ifError(e)
       results.push(r)
       assert.deepStrictEqual(expected, results)
-      done()
-    })
-  })
-
-  test('query with errors', done => {
-    const expectedError = new Error('[Microsoft][' + driver + '][SQL Server]Unclosed quotation mark after the character string \'m with NOBODY\'.')
-    expectedError.sqlstate = '42000'
-    expectedError.code = 105
-
-    const fns = [
-
-      asyncDone => {
-        assert.doesNotThrow(() => {
-          theConnection.queryRaw('I\'m with NOBODY', e => {
-            assert(e instanceof Error)
-            assert.deepStrictEqual(e, expectedError, 'Unexpected error returned')
-            asyncDone()
-          })
-        })
-      },
-
-      asyncDone => {
-        assert.doesNotThrow(() => {
-          const s = theConnection.queryRaw('I\'m with NOBODY')
-          s.on('error', e => {
-            assert(e instanceof Error)
-            assert.deepStrictEqual(e, expectedError, 'Unexpected error returned')
-            asyncDone()
-          })
-        })
-      }
-    ]
-
-    async.series(fns, () => {
       done()
     })
   })

--- a/unit.tests/txn.js
+++ b/unit.tests/txn.js
@@ -482,7 +482,13 @@ suite('txn', function () {
           const expected = new Error(`[Microsoft][${driver}][SQL Server]Unclosed quotation mark after the character string 'm with STUPID'.`)
           expected.sqlstate = '42000'
           expected.code = 105
+          expected.severity = 15
+          expected.procName = ''
+          expected.lineNumber = 1
 
+          assert(err instanceof Error)
+          assert(err.serverName.length > 0)
+          delete err.serverName
           assert.deepStrictEqual(err, expected, 'Transaction should have caused an error')
 
           theConnection.rollback(err => {

--- a/unit.tests/warnings.js
+++ b/unit.tests/warnings.js
@@ -214,6 +214,9 @@ suite('warnings', function () {
         err.code = 0
         err.sqlstate = '01000'
         err.stack = null
+        err.severity = 0
+        err.procName = ''
+        err.lineNumber = 1
         const expectedErrors = [err]
         const expectedResults = [
           {
@@ -225,6 +228,8 @@ suite('warnings', function () {
           assert.ifError(err)
           if (!more) {
             assert(warnings.length === 1)
+            assert(warnings[0].serverName.length > 0)
+            delete warnings[0].serverName
             assert.deepStrictEqual(warnings, expectedErrors)
             assert.deepStrictEqual(res, expectedResults)
           }


### PR DESCRIPTION
Adds additional diagnostic fields to SQL Server errors including:
- Severity of the error
- Server name where the error occurred
- Procedure name if the error occurred in a stored procedure
- Line number within the query/queries where the error occurred

Details on the diagnostic fields used are available [here](https://docs.microsoft.com/en-us/sql/relational-databases/native-client-odbc-api/sqlgetdiagfield?view=sql-server-ver15).

I also removed a duplicate test in `unit.tests/query.js`