### PR TITLE
Fix setUseUTC to not be tied to callback mode

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -180,15 +180,15 @@ const readerModule = ((() => {
             }
             for (let column = 0; column < driverRow.length; ++column) {
               let rowColumn = driverRow[column]
-              if (callback) {
-                if (rowColumn && useUTC === false) {
-                  if (meta[column].type === 'date') {
-                    rowColumn = new Date(rowColumn.getTime() - rowColumn.getTimezoneOffset() * -60000)
-                  }
+              if (rowColumn && useUTC === false) {
+                if (meta[column].type === 'date') {
+                  rowColumn = new Date(rowColumn.getTime() - rowColumn.getTimezoneOffset() * -60000)
                 }
+              }
+              if (callback) {
                 currentRow[column] = rowColumn
               }
-              notify.emit('column', column, rowColumn, false)
+                notify.emit('column', column, rowColumn, false)
             }
           }
         }


### PR DESCRIPTION
Address https://github.com/TimelordUK/node-sqlserver-v8/issues/205

Executing the setUseUTC() method on a connection does not seem to work. This seems to be due to the fact that it is dependent upon callback mode. If we can safely remove this, it applies the UTC translation.