### PR TITLE
Remove table_describe join to index tables

### DIFF
--- a/lib/queries/table_describe.sql
+++ b/lib/queries/table_describe.sql
@@ -66,20 +66,16 @@ FROM <table_catalog>.INFORMATION_SCHEMA.TABLES st
        AND sc.TABLE_NAME = u.TABLE_NAME
        AND sc.COLUMN_NAME = u.COLUMN_NAME
   cross join t_name_cte r
-  INNER JOIN 
+  INNER JOIN
   <table_catalog>.sys.columns c ON c.name = sc.column_name
   INNER JOIN
   <table_catalog>.sys.types t ON c.user_type_id = t.user_type_id
   INNER JOIN
   <table_catalog>.sys.tables ta ON ta.name = r.table_name
-  LEFT OUTER JOIN
-  <table_catalog>.sys.index_columns ic ON ic.object_id = c.object_id AND ic.column_id = c.column_id
-  LEFT OUTER JOIN
-  <table_catalog>.sys.indexes i ON ic.object_id = i.object_id AND ic.index_id = i.index_id
 WHERE
   c.object_id = ta.object_id
   AND TABLE_TYPE = 'BASE TABLE'
   AND sc.TABLE_NAME = r.table_name
   AND (sc.TABLE_SCHEMA = '<table_schema>' or '<table_schema>' = '')
   AND (ta.schema_id = SCHEMA_ID('<table_schema>') or '<table_schema>' = '')
-  
+


### PR DESCRIPTION
The tables in this join seem to not be used and can cause duplicate column records if a column is included in multiple indexes on the table.