### PR TITLE
Fix connection errors preventing the pool from ever being opened again

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -410,30 +410,41 @@ const poolModule = (() => {
       }
 
       async function grow () {
-        const toPromise = []
-        const existing = idle.length + busyConnectionCount + pendingCreates + parkingConnectionCount
-        if (!killed) {
-          for (let i = existing; i < options.ceiling; ++i) {
-            ++pendingCreates
-            toPromise.push(openPromise(options.connectionString))
-          }
-        }
-        const res = await Promise.all(toPromise)
-        if (res.length === 0) {
+        if (killed) {
           return
         }
+        const existing = idle.length + busyConnectionCount + pendingCreates + parkingConnectionCount
+
+        if (existing === options.ceiling) {
+          return
+        }
+
+        const toPromise = []
+        for (let i = existing; i < options.ceiling; ++i) {
+          ++pendingCreates
+          toPromise.push(openPromise(options.connectionString)
+            .then(
+              c => {
+                --pendingCreates
+                c.setSharedCache(poolProcedureCache, poolTableCache)
+                if (options.useUTC === true || options.useUTC === false) {
+                  c.setUseUTC(options.useUTC)
+                }
+                if (options.useNumericString === true || options.useNumericString === false) {
+                  c.setUseNumericString(options.useUTC)
+                }
+                checkin('grow', getDescription(c))
+              },
+              e => {
+                --pendingCreates
+                return Promise.reject(e)
+              }
+            )
+          )
+        }
+
+        const res = await Promise.all(toPromise)
         _this.emit('debug', `grow creates ${res.length} connections for pool idle = ${idle.length}, busy = ${busyConnectionCount}, pending = ${pendingCreates}, parkingConnectionCount = ${parkingConnectionCount}, existing = ${existing}`)
-        res.forEach(c => {
-          c.setSharedCache(poolProcedureCache, poolTableCache)
-          if (options.useUTC === true || options.useUTC === false) {
-            c.setUseUTC(options.useUTC)
-          }
-          if (options.useNumericString === true || options.useNumericString === false) {
-            c.setUseNumericString(options.useUTC)
-          }
-          checkin('grow', getDescription(c))
-          --pendingCreates
-        })
       }
 
       function open (cb) {


### PR DESCRIPTION
During `pool.open()` it calls `grow()` and if grow fails, the open fails. Which is all fine and dandy.

However because `await Promise.all(toPromise)` threw an exception, the pool ends up in an incorrect state of having misnumbered pendingCreates totals since the failed and closed and non-existing connections are still being marked as pending.

This further causes problems as future calls to `.open()` might actually succeeds even though zero connections are open causing the entire pool to enter invalid state and never grow or work again because of this little code:

```
if (res.length === 0) {
  return
}
```

This patch fixes those problems as opened connections get added to the pool and failed connections don't get added to the pool.