### PR TITLE
pool: Add transaction helpers and support

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -54,7 +54,7 @@ const poolModule = (() => {
     }
 
     heartbeatResponse (v) {
-      this.heatbeatSqlResponse = v
+      this.heartbeatSqlResponse = v
     }
 
     heartbeat () {
@@ -211,6 +211,7 @@ const poolModule = (() => {
 
   class PoolPromises {
     constructor (pool) {
+      this.pool = pool
       this.open = util.promisify(pool.open)
       this.close = util.promisify(pool.close)
       this.query = pool.queryAggregator
@@ -218,6 +219,43 @@ const poolModule = (() => {
       this.getUserTypeTable = pool.getUserTypeTable
       this.getTable = pool.getTable
       this.getProc = pool.getProc
+      this.beginTransaction = util.promisify(pool.beginTransaction)
+      this.commitTransaction = util.promisify(pool.commitTransaction)
+      this.rollbackTransaction = util.promisify(pool.rollbackTransaction)
+    }
+
+    transaction(cb) {
+      let connectionDescription
+      return this.beginTransaction()
+        .then((description) => cb(connectionDescription = description))
+        .then(
+          () => this.commitTransaction(connectionDescription),
+          err => {
+            // If no connectionDescription, do nothing, the beginTransaction errored
+            // and we can report it directly.
+            if (!connectionDescription) { return Promise.reject(err) }
+
+            // Error in cb() we should notify about it
+            if (this.pool.listenerCount('error') > 0) {
+              this.pool.emit('error', err)
+            }
+
+            return this.rollbackTransaction(connectionDescription)
+              .catch((rollbackError) => {
+                // We encountered error during rollback, emit an error on the pool for it
+                if (this.pool.listenerCount('error') > 0) {
+                  this.pool.emit('error', rollbackError)
+                }
+              })
+              .then(
+                () => {
+                  // Return the original error regardless if rollback was
+                  // successful or not.
+                  return Promise.reject(err)
+                },
+              )
+          }
+        )
     }
   }
 
@@ -285,6 +323,8 @@ const poolModule = (() => {
       }
 
       function runTheQuery (q, description, work) {
+        let errored = false
+
         work.poolNotifier.setQueryObj(q, work.chunky)
         q.on('submitted', () => {
           _this.emit('debug', `[${description.id}] submitted work id ${work.id}`)
@@ -297,6 +337,13 @@ const poolModule = (() => {
 
         q.on('free', () => {
           description.free()
+
+          // Transactions can not be freed yet if no errors occured. They need to be freed later
+          if (!errored && description.work && description.work.workType === workTypeEnum.TRANSACTION) {
+            _this.emit('debug', `[${description.id}] inside transaction from work id ${work.id}`)
+            return
+          }
+
           checkin('work', description)
           _this.emit('debug', `[${description.id}] free work id ${work.id}`)
           work.poolNotifier.emit('free')
@@ -306,6 +353,7 @@ const poolModule = (() => {
         })
 
         q.on('error', (e, more) => {
+          errored = true
           sendError(e, more)
           setImmediate(() => {
             crank()
@@ -322,11 +370,18 @@ const poolModule = (() => {
             break
 
           case workTypeEnum.RAW:
+          case workTypeEnum.COMMITTING:
             q = connection.queryRaw(work.sql, work.paramsOrCallback, work.callback)
             break
 
           case workTypeEnum.PROC:
             q = connection.callproc(work.sql, work.paramsOrCallback, work.callback)
+            break
+
+          case workTypeEnum.TRANSACTION:
+            q = connection.queryRaw(work.sql, work.paramsOrCallback, function (err) {
+              work.callback(err, err ? null : description)
+            })
             break
         }
         return q
@@ -346,20 +401,17 @@ const poolModule = (() => {
         poolNotifier.emit('free')
       }
 
+      /** Move unpaused items to queue */
       function promotePause () {
-        const add = []
         const start = pause.length
-        while (pause.length > 0) {
-          const item = pause.pop()
-          if (item.isPaused) {
-            add.unshift(item)
-          } else {
-            workQueue.push(item)
+
+        for (let i = 0; i < pause.length; i++) {
+          if (!pause[i].isPaused) {
+            workQueue.push(pause.splice(i, 1)[0])
+            i--
           }
         }
-        while (add.length > 0) {
-          pause.unshift(add.pop())
-        }
+
         if (start !== pause.length) {
           setImmediate(() => { crank() })
         }
@@ -395,16 +447,20 @@ const poolModule = (() => {
       const workTypeEnum = {
         QUERY: 10,
         RAW: 11,
-        PROC: 12
+        PROC: 12,
+        TRANSACTION: 13,
+        COMMITTING: 14,
       }
 
       function chunk (paramsOrCallback, callback, workType) {
         switch (workType) {
           case workTypeEnum.QUERY:
           case workTypeEnum.RAW:
+          case workTypeEnum.COMMITTING:
             return notifierFactory.getChunkyArgs(paramsOrCallback, callback)
 
           case workTypeEnum.PROC:
+          case workTypeEnum.TRANSACTION:
             return { params: paramsOrCallback, callback }
         }
       }
@@ -454,6 +510,42 @@ const poolModule = (() => {
 
       function callproc (sql, paramsOrCallback, callback) {
         return submit(sql, paramsOrCallback, callback, workTypeEnum.PROC)
+      }
+
+      function beginTransaction (callback) {
+        if (!callback || typeof callback !== 'function') {
+          throw new Error('[msnodesql] Pool beginTransaction called with empty callback.')
+        }
+        return submit('BEGIN TRANSACTION', [], callback, workTypeEnum.TRANSACTION)
+      }
+
+      function finishTransaction(sql, description, callback) {
+        if (!description instanceof PoolDscription) {
+          throw new Error('[msnodesql] Pool end transaction called with non-description.')
+        }
+        const work = description.work
+        if (!work) {
+          throw new Error('[msnodesql] Pool end transaction called with unknown or finished transaction.')
+        }
+
+        if (work.workType !== workTypeEnum.TRANSACTION && work.workType !== workTypeEnum.COMMITTING) {
+          throw new Error('[msnodesql] Pool end transaction called with unknown or finished transaction.')
+        }
+
+        _this.emit('debug', `[${description.id}] closing transaction from ${work.id} with ${sql}`)
+        work.callback = callback
+        work.sql = sql
+        work.workType = workTypeEnum.COMMITTING
+        item(description, work)
+        return work.poolNotifier
+      }
+
+      function commitTransaction (description, callback) {
+        return finishTransaction('IF (@@TRANCOUNT > 0) COMMIT TRANSACTION', description, callback)
+      }
+
+      function rollbackTransaction (description, callback) {
+        return finishTransaction('IF (@@TRANCOUNT > 0) ROLLBACK TRANSACTION', description, callback)
       }
 
       async function getUserTypeTable (name) {
@@ -651,7 +743,7 @@ const poolModule = (() => {
           description.heartbeat() // reset by user query
           checkin('heartbeat', description)
           const inactivePeriod = description.keepAliveCount * options.heartbeatSecs
-          _this.emit('debug', `[${description.id}] heartbeat response = '${description.heatbeatSqlResponse}', ${description.lastActive.toLocaleTimeString()}` +
+          _this.emit('debug', `[${description.id}] heartbeat response = '${description.heartbeatSqlResponse}', ${description.lastActive.toLocaleTimeString()}` +
             `, keepAliveCount = ${description.keepAliveCount} inactivePeriod = ${inactivePeriod}, inactivityTimeoutSecs = ${options.inactivityTimeoutSecs}`)
         })
         q.on('error', (e) => {
@@ -735,6 +827,9 @@ const poolModule = (() => {
         )
       }
 
+      this.beginTransaction = beginTransaction
+      this.commitTransaction = commitTransaction
+      this.rollbackTransaction = rollbackTransaction
       this.open = open
       this.close = close
       this.query = query


### PR DESCRIPTION
This adds some much needed support for doing transactions from a pool with a few helper utilities.
Notable new API methods:

```typescript
pool.beginTransaction(function (err, description) { /* description.connection.query() */ })
```

Pulls a connection information out of the pool and gives it to the caller. This connection becomes busy for the duration until either of next two functions are called:

```typescript
pool.commitTransaction(description, function(err) { /* err logging */ })
```

Calls `IF (@@TRANCOUNT > 0) COMMIT TRANSACTION` on the connection in the description and releases it back into the pool allowing it to be used by others.

```typescript
pool.rollbackTransaction(description, function(err) { /* err logging */ })
```

Calls `IF (@@TRANCOUNT > 0) ROLLBACK TRANSACTION` on the connection in the description and releases it back into the pool allowing it to be used by others.

Both functions are also available in the promised pool:

```typescript
let description = await pool.promises.beginTransaction()
try {
  await description.connection.promises.query(`
    SELECT * from my_table WITH (updlock, holdlock)
  `)
  // do some other stuff
  await pool.promises.commitTransaction(description)
} catch (err) {
  await pool.promises.rollbackTransaction(description)
  // log err
}
```

Lastly, a nice little promise-specific utlity has been added:

```typescript
pool.promises.transaction(async function (description) {
  /* I'm inside a transaction */
  await description.connection.promises.query(`Do transaction query here`)
})
```

This calls the callback and wraps it inside of a transaction with auto commit on success and auto rollback on any thrown errors.