### PR TITLE
fix: Windows MSVC LTO build (node 26) + Alpine prebuild apk download

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -302,6 +302,14 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    # download.microsoft.com is fronted by Akamai edges that sometimes serve an
+    # incomplete TLS chain; the musl/alpine CA bundle then can't verify it
+    # (curl error 60). Fetch the .apk on the host runner, which has a full CA
+    # store, and install the local file inside the container.
+    - name: Download msodbcsql18 apk (host)
+      run: |
+        curl -sSLO https://download.microsoft.com/download/1/f/f/1fffb537-26ab-4947-a46a-7a45c27f6f77/msodbcsql18_18.2.1.1-1_amd64.apk
+
     - name: Build in node:${{ matrix.node }}-alpine
       run: |
         docker run --rm \
@@ -309,9 +317,8 @@ jobs:
           -w /src \
           node:${{ matrix.node }}-alpine sh -c '
             set -ex
-            apk add --no-cache ca-certificates python3 make g++ unixodbc-dev curl
+            apk add --no-cache ca-certificates python3 make g++ unixodbc-dev
             update-ca-certificates || true
-            curl -sSO https://download.microsoft.com/download/1/f/f/1fffb537-26ab-4947-a46a-7a45c27f6f77/msodbcsql18_18.2.1.1-1_amd64.apk
             apk add --allow-untrusted msodbcsql18_18.2.1.1-1_amd64.apk
             rm -f msodbcsql18_18.2.1.1-1_amd64.apk
 
@@ -352,6 +359,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    # See note in prebuild-node-alpine: fetch the .apk on the host (full CA
+    # store) and install the local file inside the musl container.
+    - name: Download msodbcsql18 apk (host)
+      run: |
+        curl -sSLO https://download.microsoft.com/download/1/f/f/1fffb537-26ab-4947-a46a-7a45c27f6f77/msodbcsql18_18.2.1.1-1_amd64.apk
+
     - name: Build Electron ${{ matrix.electron }} in node:20-alpine
       env:
         ELECTRON_VERSION: ${{ matrix.electron }}
@@ -362,9 +375,8 @@ jobs:
           -e ELECTRON_VERSION \
           node:20-alpine sh -c '
             set -ex
-            apk add --no-cache ca-certificates python3 make g++ unixodbc-dev curl
+            apk add --no-cache ca-certificates python3 make g++ unixodbc-dev
             update-ca-certificates || true
-            curl -sSO https://download.microsoft.com/download/1/f/f/1fffb537-26ab-4947-a46a-7a45c27f6f77/msodbcsql18_18.2.1.1-1_amd64.apk
             apk add --allow-untrusted msodbcsql18_18.2.1.1-1_amd64.apk
             rm -f msodbcsql18_18.2.1.1-1_amd64.apk
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -180,6 +180,31 @@
                                 # Uncomment the next line to use Node-API instead of NAN
                             # "CONNECTION_USE_NODE_API",
                         ],
+                        # Node distributions compiled with clang-cl + (thin) LTO
+                        # (e.g. node 26 on Windows) leak -flto=thin / -flto=full
+                        # and /opt:lldltojobs into addon builds via the node
+                        # headers' common.gypi. MSVC's link.exe rejects
+                        # /opt:lldltojobs (LNK1117: syntax error), failing the
+                        # build. Strip the inherited LTO options from the MSVC
+                        # tools - mirrors the "-fno-lto" handling for linux below.
+                        "msvs_settings": {
+                            "VCCLCompilerTool": {
+                                "AdditionalOptions!": ["-flto=thin", "-flto=full"],
+                                "AdditionalOptions/": [["exclude", "flto"]],
+                            },
+                            "VCLibrarianTool": {
+                                "AdditionalOptions!": ["-flto=thin", "-flto=full"],
+                                "AdditionalOptions/": [["exclude", "flto|lldltojobs"]],
+                            },
+                            "VCLinkerTool": {
+                                "AdditionalOptions!": [
+                                    "-flto=thin",
+                                    "-flto=full",
+                                    "/opt:lldltojobs=2",
+                                ],
+                                "AdditionalOptions/": [["exclude", "flto|lldltojobs"]],
+                            },
+                        },
                     },
                 ],
                 [


### PR DESCRIPTION
Two prebuild/build fixes (verified locally on Windows + node 26).

## 1. Windows MSVC build fails on node 26 (`binding.gyp`)
node 26 on Windows is built with clang-cl + ThinLTO. node-gyp regenerates `config.gypi` from the running node's `process.config`, leaking `-flto=thin` and `/opt:lldltojobs=N` into addon builds via the node headers' `common.gypi`. MSVC `link.exe` rejects `/opt:lldltojobs`:

```
LINK : fatal error LNK1117: syntax error in option 'opt:lldltojobs=2'
```

Fix: strip the inherited LTO options from the MSVC compiler/librarian/linker in the `OS=="win"` branch, mirroring the existing `-fno-lto` handling in the linux branch. Uses both exact (`!`) removal and regex (`/`) exclusion so it's robust to the `lto_jobs` count and both LTO variants. No-op when those flags aren't present (node ≤ 25). Confirmed building locally with node 26.

## 2. Alpine prebuilds fail to fetch msodbcsql18 (`prebuild.yml`)
`download.microsoft.com` is fronted by Akamai edges that sometimes serve an incomplete TLS chain; the musl/alpine CA bundle then can't verify it (`curl: (60) unable to get local issuer certificate`), even with `ca-certificates` installed. Fix: download the `.apk` on the host ubuntu runner (full CA store) and install the local file inside the musl container via the mounted workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)