### PR TITLE
test: quote mocha globs so mocha expands them, not the shell

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,11 +77,11 @@
   "scripts": {
     "build": "tsc",
     "build:test": "tsc -p tsconfig.json",
-    "test": "mocha test/**/*.test.js",
+    "test": "mocha \"test/**/*.test.js\"",
     "test:improved": "mocha test/connection-improved.test.js --reporter spec",
     "test:webstorm": "mocha test/connection-webstorm.test.js --config test/.mocharc.webstorm.js",
     "test:connection": "mocha test/connect*.js --reporter spec --timeout 30000",
-    "test:watch": "mocha test/**/*.js --watch --reporter min",
+    "test:watch": "mocha \"test/**/*.js\" --watch --reporter min",
     "watch": "tsc --watch",
     "watch:test": "tsc -p tsconfig.json --watch",
     "builddbg": "node-gyp build --debug",


### PR DESCRIPTION
`npm test` ran `mocha test/**/*.test.js` unquoted. POSIX sh has no globstar, so `**` degrades to `*` and the pattern means `test/*/*.test.js`
- files exactly one directory deep. Nothing currently matches that (all 36 test files are top-level), so the shell passes the pattern through literally and mocha globs it correctly itself. It works by fallback, not by design.

The trap: the first time anyone adds a nested test file, the shell glob starts matching that file alone, mocha receives only it, and every top-level test silently stops running - with CI still green.

Demonstrated by adding a throwaway test/nested/tmp.test.js:

  unquoted, under sh:    1 passing
  quoted,   under sh:  734 passing, 1 pending

Quoting defers expansion to mocha, which supports `**` properly and matches zero or more directories. Same treatment for test:watch, which had the identical pattern. `lint` was already quoted.

No change to the resolved file set: 733 passing, 1 pending before and after.