### PR TITLE
fix: clear all 35 open CodeQL alerts, including a broken pool-wide metadata cache

### DIFF
--- a/build-config.js
+++ b/build-config.js
@@ -1,12 +1,10 @@
 // build-config.js - Common configuration for both node-gyp and CMake
 const fs = require('fs');
-const path = require('path');
 const os = require('os');
 
 // Platform detection
 const isWindows = os.platform() === 'win32';
 const isMac = os.platform() === 'darwin';
-const isLinux = !isWindows && !isMac;
 
 // Common configuration
 const config = {

--- a/examples/logging-performance.js
+++ b/examples/logging-performance.js
@@ -51,6 +51,12 @@ for (let i = 0; i < iterations; i++) {
 }
 console.timeEnd('String interpolation (always evaluated)')
 
+console.time('Early exit check (string still built)')
+for (let i = 0; i < iterations; i++) {
+  exampleWithEarlyExit(i, testData)
+}
+console.timeEnd('Early exit check (string still built)')
+
 console.time('Lazy evaluation (function not called)')
 for (let i = 0; i < iterations; i++) {
   exampleWithLazyEvaluation(i, testData)
@@ -66,6 +72,12 @@ for (let i = 0; i < 100; i++) { // Fewer iterations when logging
   exampleWithStringInterpolation(i, testData)
 }
 console.timeEnd('String interpolation (with logging)')
+
+console.time('Early exit check (with logging)')
+for (let i = 0; i < 100; i++) {
+  exampleWithEarlyExit(i, testData)
+}
+console.timeEnd('Early exit check (with logging)')
 
 console.time('Lazy evaluation (with logging)')
 for (let i = 0; i < 100; i++) {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -73,7 +73,7 @@ class PrivateConnection {
   }
 
   decodeSqlServerVersion (connectionString) {
-    const myRegexp = /Driver=\{ODBC Driver (.*?) for SQL Server}.*$/g
+    const myRegexp = /Driver=\{ODBC Driver (\d+) for SQL Server\}/
     const match = myRegexp.exec(connectionString)
     return match !== null ? parseInt(match[1]) : 17
   }

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -158,6 +158,10 @@ class ConnectionWrapper {
   setSharedCache (pc, tc) {
     this.procedureCache = pc
     this.tableCache = tc
+    // the managers copy the reference in their constructor, so the caches have
+    // to be pushed down - assigning the fields alone leaves them on their own.
+    this.procedures.setCache(pc)
+    this.tables.setCache(tc)
   }
 
   getUserTypeTable (name, callback) {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1301,6 +1301,17 @@ declare namespace MsNodeSqlV8 {
 
     setPolling: (poll: boolean) => void
 
+    /**
+     * empty the metadata cache - required after DDL changes the shape of a
+     * cached object, since a pool shares one cache across all connections.
+     */
+    clear: () => void
+
+    /**
+     * number of entries currently held in the metadata cache
+     */
+    getCount: () => number
+
     ServerDialect: ServerDialect
   }
 
@@ -1509,6 +1520,17 @@ declare namespace MsNodeSqlV8 {
 
     // or use builder to build columns
     ServerDialect: ServerDialect
+
+    /**
+     * empty the metadata cache - required after DDL changes the shape of a
+     * cached object, since a pool shares one cache across all connections.
+     */
+    clear: () => void
+
+    /**
+     * number of entries currently held in the metadata cache
+     */
+    getCount: () => number
 
     makeColumn: (tableName: string, tableSchema: string, position: number, columnName: string, paramType: string, paramLength: number, isPrimaryKey: number) => TableColumn
   }

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -592,7 +592,7 @@ const poolModule = (() => {
       }
 
       function finishTransaction (sql, description, callback) {
-        if ((!description) instanceof PoolDescription) {
+        if (!(description instanceof PoolDescription)) {
           throw new Error('[msnodesql] Pool end transaction called with non-description.')
         }
         const work = description.work

--- a/lib/procedure.js
+++ b/lib/procedure.js
@@ -134,6 +134,10 @@ const procedureModule = ((() => {
       this.timeout = t
     }
 
+    setCache (cache) {
+      this.cache = cache || {}
+    }
+
     clear () {
       Object.keys(this.cache).forEach(k => {
         delete this.cache[k]

--- a/lib/table.js
+++ b/lib/table.js
@@ -104,7 +104,7 @@ const tableModule = (() => {
 
     addMeta (tableName, columns, dialect) {
       const tableMeta = new TableMeta(tableName, columns, dialect)
-      this.cache[tableMeta] = tableMeta
+      this.cache[tableName] = tableMeta
       return tableMeta
     }
 
@@ -139,6 +139,22 @@ const tableModule = (() => {
           resolve(tableMeta)
         }
       })
+    }
+
+    // the pool injects one shared cache into every member connection so table
+    // metadata is fetched once rather than once per connection.
+    setCache (cache) {
+      this.cache = cache || {}
+    }
+
+    clear () {
+      Object.keys(this.cache).forEach(k => {
+        delete this.cache[k]
+      })
+    }
+
+    getCount () {
+      return Object.keys(this.cache).length
     }
 
     getBulk (table, meta) {

--- a/samples/javascript/pool-scaling.js
+++ b/samples/javascript/pool-scaling.js
@@ -1,4 +1,3 @@
-const sql = require('msnodesqlv8')
 const { TestEnv } = require('../../test/env/test-env')
 const env = new TestEnv()
 const connectionString = env.connectionString

--- a/samples/javascript/test-pool-specific.js
+++ b/samples/javascript/test-pool-specific.js
@@ -1,4 +1,3 @@
-const sql = require('./lib/sql')
 const { TestEnv } = require('./test/env/test-env')
 const env = new TestEnv()
 

--- a/samples/javascript/test-scaling-strategies.js
+++ b/samples/javascript/test-scaling-strategies.js
@@ -1,4 +1,3 @@
-const sql = require('./lib/index')
 
 // Example configurations for different scaling strategies
 

--- a/samples/javascript/txn.js
+++ b/samples/javascript/txn.js
@@ -172,7 +172,9 @@ async function runner () {
     countSql: `select count(*) as count from ${table}`
   }
 
-  const scenario = scenario7
+  // pick the scenario to run - see the comments above each definition
+  const scenarios = { scenario1, scenario2, scenario3, scenario4, scenario5, scenario7 }
+  const scenario = scenarios.scenario7
 
   const saConnection = await mssql.promises.open(saString)
   const opens = Array(scenario.connections).fill(0).map(() => mssql.promises.open(connectionString))

--- a/samples/typescript/db-backup.ts
+++ b/samples/typescript/db-backup.ts
@@ -6,9 +6,8 @@ const sqlQuery = `BACKUP DATABASE [AdventureWorks2019] TO  DISK = N'H:\\sql serv
 NOFORMAT, INIT,  NAME = N'SampleDb-Full Database Backup', SKIP, NOREWIND, NOUNLOAD,  STATS = 10`
 
 const query = sql.query(connectionString, sqlQuery, (err, rows, more) => {
-  more = more ?? false
-  if (more) return
-  console.error(`cb more ${more ? 'T' : 'F'}`)
+  if (more ?? false) return
+  console.error('cb more F')
   if (err != null) {
     console.error('cb err')
   } else {

--- a/samples/typescript/demo-support.js
+++ b/samples/typescript/demo-support.js
@@ -77,7 +77,7 @@ const GlobalConn = (() => {
           driver,
           database,
           conn_str: cs,
-          support: new DemoSupport(sql, cs),
+          support: new DemoSupport(sql),
           async: new ds.Async(),
           helper: new ds.EmployeeHelper(sql, cs)
         }
@@ -88,7 +88,7 @@ const GlobalConn = (() => {
         driver,
         database,
         conn_str: candidateConnStr,
-        support: new DemoSupport(sql, candidateConnStr),
+        support: new DemoSupport(sql),
         async: new ds.Async(),
         helper: new ds.EmployeeHelper(sql, candidateConnStr)
       }

--- a/test/common/connection-config.ts
+++ b/test/common/connection-config.ts
@@ -1,6 +1,5 @@
 // test/common/connection-config.ts
 import * as dotenv from 'dotenv'
-import * as path from 'path'
 
 // Load environment variables from .env file
 dotenv.config()

--- a/test/common/logging-helper.js
+++ b/test/common/logging-helper.js
@@ -62,7 +62,6 @@ function configureTestLogging (sql) {
 
   // Only show configuration if not silent
   if (logLevel !== 'SILENT') {
-    const config = sql.logger.getConfiguration()
     console.log('Test logging configured:', {
       level: logLevel,
       console: consoleLogging,

--- a/test/compoundqueries.test.js
+++ b/test/compoundqueries.test.js
@@ -6,7 +6,6 @@ const { TestEnv } = require('./env/test-env')
 const env = new TestEnv()
 const chai = require('chai')
 const assert = chai.assert
-const expect = chai.expect
 
 // Enable trace-level logging for debugging test failures
 const sql = require('../lib/sql')
@@ -100,7 +99,7 @@ describe('compoundqueries', function () {
     const testdata1 = null
     const testdata2Expected = 'string data row 2'
     const testdata2TsqlInsert = '\'' + testdata2Expected + '\''
-    const tsql = `SELECT * FROM ${tablename} ORDER BY id;  INSERT INTO ${tablename} (${testcolumnname}) VALUES (${testdata1});SELECT * FROM ${tablename} ORDER BY id;`
+    const tsql = `SELECT * FROM ${tablename} ORDER BY id;  INSERT INTO ${tablename} (${testcolumnname}) VALUES (NULL);SELECT * FROM ${tablename} ORDER BY id;`
 
     const expected1 = {
       meta: [
@@ -340,7 +339,7 @@ describe('compoundqueries', function () {
     const testdata1 = null
     const testdata2Expected = 'string data row 2'
     const testdata2TsqlInsert = `'${testdata2Expected}'`
-    const tsql = `SELECT * FROM ${tablename} ORDER BY id;  INSERT INTO ${invalidtablename} (${testcolumnname}) VALUES (${testdata1});SELECT * FROM ${tablename} ORDER BY id;`
+    const tsql = `SELECT * FROM ${tablename} ORDER BY id;  INSERT INTO ${invalidtablename} (${testcolumnname}) VALUES (NULL);SELECT * FROM ${tablename} ORDER BY id;`
 
     const expectedError = new Error('[Microsoft][' + driver + '][SQL Server]Invalid object name \'' + invalidtablename + '\'.')
     expectedError.sqlstate = '42S02'

--- a/test/concurrent.test.js
+++ b/test/concurrent.test.js
@@ -4,7 +4,6 @@ const { TestEnv } = require('./env/test-env')
 const env = new TestEnv()
 const chai = require('chai')
 const assert = chai.assert
-const expect = chai.expect
 const sql = require('../lib/sql')
 
 const { configureTestLogging } = require('./common/logging-helper')

--- a/test/connection-pool.test.js
+++ b/test/connection-pool.test.js
@@ -323,7 +323,7 @@ describe('pool', function () {
 
       expect(() => {
         pool.commitTransaction(null, () => {})
-      }).to.throw('Cannot read properties of null')
+      }).to.throw('[msnodesql] Pool end transaction called with non-description.')
 
       await pool.promises.close()
     })
@@ -334,7 +334,7 @@ describe('pool', function () {
 
       expect(() => {
         pool.rollbackTransaction({}, () => {})
-      }).to.throw('[msnodesql] Pool end transaction called with unknown or finished transaction.')
+      }).to.throw('[msnodesql] Pool end transaction called with non-description.')
 
       await pool.promises.close()
     })

--- a/test/connection-webstorm.test.js
+++ b/test/connection-webstorm.test.js
@@ -6,7 +6,7 @@
 'use strict'
 
 const { describe, it, beforeEach, afterEach } = require('mocha')
-const { assert, expect } = require('chai')
+const { assert } = require('chai')
 const { TestEnv } = require('./env/test-env')
 
 /**

--- a/test/datatypes.test.js
+++ b/test/datatypes.test.js
@@ -29,7 +29,6 @@ const env = new TestEnv()
 const chai = require('chai')
 chai.use(chaiAsPromised)
 const expect = chai.expect
-const assert = chai.assert
 
 // Enable trace-level logging for debugging test failures
 const sql = require('../lib/sql')

--- a/test/encrypt.test.js
+++ b/test/encrypt.test.js
@@ -8,7 +8,6 @@ const env = new TestEnv()
 const chai = require('chai')
 chai.use(chaiAsPromised)
 const expect = chai.expect
-const assert = chai.assert
 
 const sql = require('../lib/sql')
 const { configureTestLogging } = require('./common/logging-helper')

--- a/test/env/test-env.js
+++ b/test/env/test-env.js
@@ -17,7 +17,6 @@ const { EncryptHelper } = require('./encrypt-helper')
 const util = require('util')
 const fs = require('fs')
 const path = require('path')
-const chai = require('chai')
 
 class CommonTestFnPromises {
   constructor () {

--- a/test/json.test.js
+++ b/test/json.test.js
@@ -3,7 +3,6 @@
 const { TestEnv } = require('./env/test-env')
 const env = new TestEnv()
 const chai = require('chai')
-const assert = chai.assert
 const expect = chai.expect
 const sql = require('../lib/sql')
 

--- a/test/pool-growth-current-behavior.test.js
+++ b/test/pool-growth-current-behavior.test.js
@@ -2,7 +2,6 @@
 
 /* global describe it */
 
-const assert = require('assert')
 const { TestEnv } = require('./env/test-env')
 
 describe('pool growth current behavior', function () {

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -25,14 +25,12 @@ const chai = require('chai')
 const assert = chai.assert
 const expect = chai.expect
 const { TestEnv } = require('./env/test-env')
-const sql = require('../lib/sql')
 const env = new TestEnv()
 
 describe('query', function () {
   this.timeout(30000)
 
   this.beforeEach(done => {
-    const { configureTestLogging } = require('./common/logging-helper')
     env.open().then(() => {
       done()
     }).catch(e => {

--- a/test/stress/stress-test-runner.ts
+++ b/test/stress/stress-test-runner.ts
@@ -1,5 +1,4 @@
 import * as sql from 'msnodesqlv8'
-import * as os from 'os'
 
 interface StressTestConfig {
   connectionString?: string

--- a/test/tvp.test.js
+++ b/test/tvp.test.js
@@ -6,7 +6,6 @@ const env = new TestEnv()
 const chai = require('chai')
 chai.use(chaiAsPromised)
 const expect = chai.expect
-const assert = chai.assert
 
 const sql = require('../lib/sql')
 const { configureTestLogging } = require('./common/logging-helper')
@@ -288,7 +287,7 @@ describe('tvp', function () {
     builder.addColumn('displayOrder').asInt().null()
 
     // Setup table and TVP using builder pattern (like BuilderChecker.checkTvp)
-    const table = builder.toTable()
+    builder.toTable()
     await builder.drop()
     await builder.create()
 

--- a/test/userbind.test.js
+++ b/test/userbind.test.js
@@ -8,7 +8,6 @@ const env = new TestEnv()
 const chai = require('chai')
 chai.use(chaiAsPromised)
 const expect = chai.expect
-const assert = chai.assert
 
 const sql = require('../lib/sql')
 const { configureTestLogging } = require('./common/logging-helper')


### PR DESCRIPTION
Clears every open CodeQL alert (35: 1 high, 7 warning, 27 note). Three turned out to be real bugs rather than lint noise.

## Real fixes

**Polynomial ReDoS in `decodeSqlServerVersion`** (the only high severity alert). The version was matched with `(.*?)` followed by an unanchored `.*$`, which backtracks quadratically on a crafted connection string. The capture is passed straight to `parseInt`, so `\d+` is exact rather than a workaround. 17/18/11 still decode, non-matching strings still fall back to 17, and a 50k character attack payload now returns in under a millisecond.

**Pool end-transaction guard never fired.** `(!description) instanceof PoolDescription` negates first, so the test was `boolean instanceof PoolDescription` — always false. `commitTransaction(null)` fell through to `description.work` and surfaced a raw `TypeError`. Two tests asserted that `TypeError` text and are updated to the real error. The stricter guard cannot reject valid input: the description handed to the transaction callback is the `PoolDescription` built by `newDescription`, the promise wrappers are plain `util.promisify` pass-throughs, and `PoolPromises.transaction` already short-circuits on a falsy description before reaching rollback.

**The pool-wide metadata cache never worked.** The pool creates one procedure cache and one table cache and injects them into every member connection (`pool.js:733`) so metadata is fetched once rather than once per connection. Two defects meant that never happened:

1. `TableMgr.addMeta` keyed the cache by the meta object rather than the table name, so every entry stringified to `"[object Object]"`. `describe()` looked up by name and never hit, and each `addMeta` overwrote the single slot. `ProcedureMgr` already keys by name, which confirms the intent.
2. `setSharedCache` assigned connection fields that nothing reads. Both managers copy the cache reference in their constructor, where the fields are still `null`, so both had already fallen back to a private `{}`. The caches now have to be pushed down, so both managers gain `setCache`.

Note that procedure caching was affected too — `ProcedureMgr` keys correctly so per-connection caching worked, but pool-wide sharing did not, for the same reason.

This also adds `clear()` and `getCount()` to `TableMgr`, mirroring the ones `ProcedureMgr` already had, and declares both pairs on `TableManager` and `ProcedureManager` (`ProcedureMgr`'s were undeclared). Invalidation matters more now that the cache is live and shared: DDL that reshapes a cached table would otherwise poison every connection in the pool for its lifetime with no way to flush it.

## Quality alerts

The remaining 31 are mostly dead requires and aliases across 15 files. Two files were wired up rather than stripped, since the flagged code is the point of the file: `txn.js` `scenario1`-`scenario5` are a documented menu that `const scenario = scenario7` picks from, now referenced through a `scenarios` map, and `exampleWithEarlyExit` is method 2 of 3 in `logging-performance.js` and was simply missing from the benchmark it demonstrates.

Also: `demo-support.js` passed a connection string to `DemoSupport(native)`, which takes one parameter, so it was silently dropped; `db-backup.ts` formatted `more` with a ternary after an early return had already proved it false; `compoundqueries.test.js` interpolated a `null` into SQL to get the `NULL` keyword, which now says `NULL` outright. `tvp.test.js` keeps the `builder.toTable()` call and drops only the unused binding, since `toTable()` has side effects.

## Verification

Full test suite run locally against SQL Server by @TimelordUK. `tsc --noEmit` clean.

The cache chain was verified without a database: two connections' managers are `!==` before injection and `===` after, both point at the pool's own cache objects, one connection's `addMeta` is visible to the other, `describe()` resolves from cache with no server round trip, and a connection with no injected cache stays isolated.

## Unrelated, not fixed here

`npm run lint` cannot run at all — `typescript@^7.0.2` and typescript-eslint are incompatible ("typescript-eslint does not support TS 7.0"), aborting at plugin load before any file is parsed. That is why none of these unused-variable issues ever surfaced locally. Worth its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
