### PR TITLE
feat(ci): add workflow to promote an npm dist-tag

### DIFF
--- a/.github/workflows/promote-tag.yml
+++ b/.github/workflows/promote-tag.yml
@@ -1,0 +1,73 @@
+name: NPM Promote Dist-Tag
+
+# Points an npm dist-tag (latest, next, beta...) at an already-published
+# version. Useful after publishing under `next` for soak testing, and as the
+# rollback lever if a release turns out bad -- unpublish is only possible for
+# 72 hours, but re-pointing `latest` at the previous version works forever.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Published version to promote (e.g. 5.3.0)'
+        required: true
+        type: string
+      tag:
+        description: 'Dist-tag to point at that version'
+        required: true
+        default: 'latest'
+        type: string
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+
+    steps:
+    # No checkout needed -- dist-tag only talks to the registry.
+    - name: Setup Node.js
+      uses: actions/setup-node@v7
+      with:
+        # Registry client only -- does not constrain what the package supports.
+        node-version: '24'
+        registry-url: 'https://registry.npmjs.org'
+
+    - name: Verify version is published
+      run: |
+        echo "🔍 Checking msnodesqlv8@${{ inputs.version }} exists on the registry..."
+        if ! npm view "msnodesqlv8@${{ inputs.version }}" version; then
+          echo "❌ msnodesqlv8@${{ inputs.version }} is not published -- nothing to promote."
+          exit 1
+        fi
+
+    - name: Show current dist-tags
+      run: |
+        echo "🏷️  Before:"
+        npm dist-tag ls msnodesqlv8
+
+    - name: Promote dist-tag
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      run: |
+        if [ -z "$NODE_AUTH_TOKEN" ]; then
+          echo "❌ NPM_TOKEN secret is not set. Add it under Settings > Secrets and variables > Actions."
+          exit 1
+        fi
+
+        echo "🚀 Pointing '${{ inputs.tag }}' at msnodesqlv8@${{ inputs.version }}"
+        npm dist-tag add "msnodesqlv8@${{ inputs.version }}" "${{ inputs.tag }}"
+
+    - name: Show resulting dist-tags
+      run: |
+        echo "🏷️  After:"
+        npm dist-tag ls msnodesqlv8
+
+    - name: Summary
+      if: always()
+      run: |
+        echo "## 🏷️ Dist-Tag Promotion" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "- **Package**: msnodesqlv8@${{ inputs.version }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Tag**: ${{ inputs.tag }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Result**: ${{ job.status == 'success' && '✅ Promoted' || '❌ Failed' }}" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "Install with: \`npm install msnodesqlv8@${{ inputs.tag }}\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Problem

Publishing under `next` for soak testing leaves no in-repo way to flip `latest` afterwards. The `NPM_TOKEN` lives only in the repo secret (write-only, can't be read back), so promoting a release meant running `npm dist-tag add` from a machine with local npm credentials — which errors with `401 Unauthorized` if you don't happen to have any.

## Change

Adds `.github/workflows/promote-tag.yml`, a `workflow_dispatch` job taking two inputs:

- `version` — the already-published version (e.g. `5.3.0`)
- `tag` — the dist-tag to point at it (defaults to `latest`)

It runs `npm dist-tag add` against the registry using the existing `NPM_TOKEN` secret. No `actions/checkout` — `dist-tag` only talks to the registry, never the working tree.

Steps:

1. Setup Node 24 with `registry-url` (matches `npm-publish.yml`)
2. Verify the version is actually published — fails fast with a clear message rather than a confusing 404 from `dist-tag add`
3. Print dist-tags **before**
4. `npm dist-tag add`, guarding against an unset secret
5. Print dist-tags **after**
6. Step summary

## Why it's worth having beyond the immediate 401

This is also the release rollback lever. Unpublishing is only possible within 72 hours, but re-pointing `latest` at the previous version works indefinitely — so if a release turns out bad a week later, this is the fix.

## Note for whoever runs it first

If the `NPM_TOKEN` secret is a **granular** token, check it has write permission on `msnodesqlv8` and hasn't expired — granular tokens default to a 30-day life. A classic Automation token has no expiry and bypasses 2FA. A 401 at the promote step means the token, not the command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)