### PR TITLE
Fix/446 diagnostic text utf8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,7 +103,15 @@ jobs:
 
     - name: Install dependencies
       working-directory: node_modules/msnodesqlv8
-      run: npm install
+      # Build the addon from this checkout. Without the flag, npm runs the package's own
+      # install script, `prebuild-install || node-gyp rebuild`, and prebuild-install
+      # succeeds: every release carries napi-v8 prebuilds, which match any Node version on
+      # every platform we test. The addon under test would then be the last *published*
+      # binary, so no C++ change on a branch is ever compiled here, let alone exercised -
+      # a C++ fix looks broken and a C++ regression looks fine. --build-from-source makes
+      # prebuild-install decline with exit 1 so the fallback compiles the source. It is
+      # scoped to this package by name so no other dependency is forced to compile.
+      run: npm install --build-from-source=msnodesqlv8
 
     - name: Build TypeScript
       working-directory: node_modules/msnodesqlv8
@@ -187,7 +195,15 @@ jobs:
 
     - name: Install dependencies
       working-directory: node_modules/msnodesqlv8
-      run: npm install
+      # Build the addon from this checkout. Without the flag, npm runs the package's own
+      # install script, `prebuild-install || node-gyp rebuild`, and prebuild-install
+      # succeeds: every release carries napi-v8 prebuilds, which match any Node version on
+      # every platform we test. The addon under test would then be the last *published*
+      # binary, so no C++ change on a branch is ever compiled here, let alone exercised -
+      # a C++ fix looks broken and a C++ regression looks fine. --build-from-source makes
+      # prebuild-install decline with exit 1 so the fallback compiles the source. It is
+      # scoped to this package by name so no other dependency is forced to compile.
+      run: npm install --build-from-source=msnodesqlv8
 
     - name: Build TypeScript
       working-directory: node_modules/msnodesqlv8
@@ -246,7 +262,15 @@ jobs:
 
     - name: Install dependencies
       working-directory: node_modules/msnodesqlv8
-      run: npm install
+      # Build the addon from this checkout. Without the flag, npm runs the package's own
+      # install script, `prebuild-install || node-gyp rebuild`, and prebuild-install
+      # succeeds: every release carries napi-v8 prebuilds, which match any Node version on
+      # every platform we test. The addon under test would then be the last *published*
+      # binary, so no C++ change on a branch is ever compiled here, let alone exercised -
+      # a C++ fix looks broken and a C++ regression looks fine. --build-from-source makes
+      # prebuild-install decline with exit 1 so the fallback compiles the source. It is
+      # scoped to this package by name so no other dependency is forced to compile.
+      run: npm install --build-from-source=msnodesqlv8
 
     - name: Build TypeScript
       working-directory: node_modules/msnodesqlv8

--- a/cpp/include/common/odbc_common.h
+++ b/cpp/include/common/odbc_common.h
@@ -147,25 +147,70 @@ class odbcstr {
     return ret;
   }
 
+  /**
+   * Convert a driver-supplied SQLWCHAR buffer to UTF-8.
+   *
+   * `l` counts SQLWCHAR units, not bytes, and may exceed the buffer: `trim` derives it
+   * from `capacity()`, and `SQLGetDiagRecW` reports the length *available* rather than
+   * the length written. It is clamped to `size()` here so neither can read off the end.
+   *
+   * `SQLWCHAR` is UTF-16 where it is two bytes (Windows, unixODBC's default ABI) and
+   * UTF-32 where it is four (iODBC), so surrogate pairs are recombined only in the
+   * two-byte case.
+   *
+   * Trailing NULs are dropped, because two callers pass the *buffer* size rather than a
+   * string length and rely on the terminator. An **embedded** NUL is kept: a diagnostic
+   * message that legitimately contains U+0000 must not lose everything after it.
+   */
   static string swcvec2str(const vector<SQLWCHAR>& v, const size_t l) {
-    vector<char> c_str;
-    c_str.reserve(l + 1);
-    c_str.resize(l + 1);
-    constexpr auto c = static_cast<int>(sizeof(SQLWCHAR));
-    const auto* ptr = reinterpret_cast<const char*>(v.data());
-    for (size_t i = 0, j = 0; i < l * c; i += c, j++) {
-      c_str[j] = ptr[i];
+    size_t take = min(l, v.size());
+    while (take > 0 && v[take - 1] == 0) {
+      --take;
     }
-    if (l > 0)
-      c_str.resize(l - 1);
-    string s(c_str.data());
-    return s;
+    string out;
+    out.reserve(take);
+    for (size_t i = 0; i < take; ++i) {
+      auto cp = static_cast<char32_t>(static_cast<uint32_t>(v[i]));
+      if (sizeof(SQLWCHAR) == 2 && cp >= 0xD800 && cp <= 0xDBFF && i + 1 < take) {
+        const auto low = static_cast<char32_t>(static_cast<uint32_t>(v[i + 1]));
+        if (low >= 0xDC00 && low <= 0xDFFF) {
+          cp = 0x10000 + ((cp - 0xD800) << 10) + (low - 0xDC00);
+          ++i;
+        }
+      }
+      // A lone surrogate or an out-of-range unit cannot be encoded. U+FFFD keeps the
+      // rest of the text readable, which is the whole point of a diagnostic message.
+      if ((cp >= 0xD800 && cp <= 0xDFFF) || cp > 0x10FFFF) {
+        cp = 0xFFFD;
+      }
+      appendUtf8(out, cp);
+    }
+    return out;
   }
 
   static std::string trim(const vector<SQLWCHAR>& v, SQLSMALLINT len) {
-    auto take = min(v.capacity(), (size_t)len);
+    auto take = min(v.size(), (size_t)len);
     auto c_msg = odbcstr::swcvec2str(v, take);
     return c_msg;
+  }
+
+ private:
+  static void appendUtf8(string& out, const char32_t cp) {
+    if (cp < 0x80) {
+      out.push_back(static_cast<char>(cp));
+    } else if (cp < 0x800) {
+      out.push_back(static_cast<char>(0xC0 | (cp >> 6)));
+      out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+    } else if (cp < 0x10000) {
+      out.push_back(static_cast<char>(0xE0 | (cp >> 12)));
+      out.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
+      out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+    } else {
+      out.push_back(static_cast<char>(0xF0 | (cp >> 18)));
+      out.push_back(static_cast<char>(0x80 | ((cp >> 12) & 0x3F)));
+      out.push_back(static_cast<char>(0x80 | ((cp >> 6) & 0x3F)));
+      out.push_back(static_cast<char>(0x80 | (cp & 0x3F)));
+    }
   }
 };
 

--- a/cpp/include/common/platform.h
+++ b/cpp/include/common/platform.h
@@ -12,6 +12,7 @@
 #endif
 
 // Common C++ headers
+#include <cstdint>
 #include <vector>
 #include <queue>
 #include <string>

--- a/cpp/include/odbc/odbc_handles.h
+++ b/cpp/include/odbc/odbc_handles.h
@@ -96,12 +96,37 @@ class OdbcHandleImpl : public InterfaceType {
                                              sql_state.data(),
                                              &native_error,
                                              msg.data(),
-                                             msg.capacity(),
+                                             static_cast<SQLSMALLINT>(msg.size()),
                                              &msg_len)) != SQL_NO_DATA) {
       SQL_LOG_TRACE_STREAM("SQLGetDiagRecW returned: " << rc2 << " for record: " << i);
       if (rc2 < 0) {
         SQL_LOG_ERROR_STREAM("SQLGetDiagRecW failed with return code: " << rc2);
         break;
+      }
+      // `SQLGetDiagRecW` reports the number of characters **available**, not the number
+      // written, so a message longer than the buffer has already been cut. Ask again for
+      // the same record with a buffer that fits: a PRINT of a generated statement runs
+      // past 10240 routinely -- `print cast(substring(@sql, 1, 16000) as ntext)` is the
+      // documented way around PRINT's own 4000/8000 limit -- and a statement 5761
+      // characters shorter than it should be still looks like a statement.
+      //
+      // `msg_len` is a SQLSMALLINT, so the ODBC API caps one record at 32767 characters
+      // whatever we do here; the buffer is grown no further than that.
+      if (msg_len > 0 && static_cast<size_t>(msg_len) >= msg.size()) {
+        constexpr size_t max_diag_chars = 32767;
+        msg.assign(min(static_cast<size_t>(msg_len) + 1, max_diag_chars), 0);
+        rc2 = odbcApiPtr->SQLGetDiagRecW(HandleType,
+                                         handle_,
+                                         i,
+                                         sql_state.data(),
+                                         &native_error,
+                                         msg.data(),
+                                         static_cast<SQLSMALLINT>(msg.size()),
+                                         &msg_len);
+        if (rc2 < 0) {
+          SQL_LOG_ERROR_STREAM("SQLGetDiagRecW failed on retry with return code: " << rc2);
+          break;
+        }
       }
       auto c_msg = odbcstr::trim(msg, msg_len);
       auto c_state = odbcstr::swcvec2str(sql_state, sql_state.size());

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -523,3 +523,56 @@ gtest_discover_tests(cpp_tests
         TIMEOUT 120
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
+# ---------------------------------------------------------------------------------------
+# Standalone diagnostics tests (issue #446)
+#
+# The diagnostic text path - odbcstr::swcvec2str and OdbcHandleImpl::read_errors - lives
+# entirely in headers, so it needs nothing from the addon beyond Logger.cpp and the gmock
+# ODBC api. It is built as its own target so these regression tests can be run on their
+# own, and so they keep working while cpp_tests cannot build: mocks/include/
+# mock_odbc_statement.h is out of date against the current IOdbcStatement interface.
+#
+#   cmake --build test/cpp/build --config Debug --target diagnostics_tests
+#   test/cpp/build/Debug/diagnostics_tests
+# ---------------------------------------------------------------------------------------
+add_executable(diagnostics_tests
+    "${CMAKE_CURRENT_SOURCE_DIR}/unit/diagnostic_text_test.cpp"
+    "../../cpp/src/utils/Logger.cpp"
+)
+
+target_compile_definitions(diagnostics_tests PRIVATE
+    UNIT_TEST=1
+    NAPI_DISABLE_CPP_EXCEPTIONS
+)
+
+if(WIN32)
+    target_compile_definitions(diagnostics_tests PRIVATE
+        WINDOWS_BUILD
+        UNICODE=1
+    )
+    set_target_properties(diagnostics_tests PROPERTIES LINK_FLAGS "/NODEFAULTLIB:msvcrt.lib")
+endif()
+
+target_include_directories(diagnostics_tests PRIVATE
+    "../../cpp"
+    "../../cpp/include"
+    "../../cpp/include/common"
+    "../../cpp/include/odbc"
+    "../../cpp/include/utils"
+    "${CMAKE_CURRENT_SOURCE_DIR}/mocks/include"
+)
+
+target_link_libraries(diagnostics_tests PRIVATE
+    ${ODBC_LIBRARIES}
+    GTest::gtest
+    GTest::gtest_main
+    GTest::gmock
+)
+
+gtest_discover_tests(diagnostics_tests
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    DISCOVERY_MODE PRE_TEST
+    PROPERTIES
+        TIMEOUT 120
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+)

--- a/test/cpp/mocks/include/mock_odbc_api.h
+++ b/test/cpp/mocks/include/mock_odbc_api.h
@@ -180,5 +180,35 @@ namespace mssql
                 (SQLSMALLINT HandleType,
                  SQLHANDLE Handle),
                 (override));
+
+    MOCK_METHOD(SQLRETURN, SQLSetEnvAttr,
+                (SQLHENV EnvironmentHandle,
+                 SQLINTEGER Attribute,
+                 SQLPOINTER Value,
+                 SQLINTEGER StringLength),
+                (override));
+
+    MOCK_METHOD(SQLRETURN, SQLGetDiagField,
+                (SQLSMALLINT HandleType,
+                 SQLHANDLE Handle,
+                 SQLSMALLINT RecNumber,
+                 SQLSMALLINT DiagIdentifier,
+                 SQLPOINTER DiagInfo,
+                 SQLSMALLINT BufferLength,
+                 SQLSMALLINT *StringLength),
+                (override));
+
+    MOCK_METHOD(SQLRETURN, SQLCloseCursor,
+                (SQLHSTMT StatementHandle),
+                (override));
+
+    MOCK_METHOD(SQLRETURN, SQLGetDescField,
+                (SQLHDESC DescriptorHandle,
+                 SQLSMALLINT RecNumber,
+                 SQLSMALLINT FieldIdentifier,
+                 SQLPOINTER Value,
+                 SQLINTEGER BufferLength,
+                 SQLINTEGER *StringLength),
+                (override));
   };
 }

--- a/test/cpp/unit/diagnostic_text_test.cpp
+++ b/test/cpp/unit/diagnostic_text_test.cpp
@@ -1,0 +1,266 @@
+// Regression tests for issue #446 - diagnostic message text.
+//
+// PRINT / RAISERROR text reaches JavaScript through odbcstr::swcvec2str and
+// OdbcHandleImpl::read_errors. Three defects were reported and reproduced against a real
+// server on ODBC Driver 17:
+//
+//   1. swcvec2str kept the low byte of each UTF-16 code unit, so every character above
+//      U+00FF was replaced - U+017C (z with dot) narrowed to 0x7C, which is '|', and
+//      U+0142 (l with stroke) to 0x42, which is 'B' - or, where the low byte was not
+//      printable ASCII, dropped or turned into U+FFFD once JavaScript decoded the bytes
+//      as UTF-8.
+//   2. A code unit whose low byte was 0x00 - U+0100, or a genuine U+0000 - narrowed to a
+//      NUL, and the string was then built from a NUL-terminated buffer, so the message
+//      ended there.
+//   3. read_errors sized the buffer at 10 * 1024 and ignored the length SQLGetDiagRecW
+//      reports, which is the length *available* rather than the length written, so a
+//      longer record arrived cut to 10239 characters with no error.
+//
+// These tests need neither a SQL Server nor a driver: the string conversion is pure, and
+// the truncation case drives read_errors through a mocked SQLGetDiagRecW.
+//
+// Kept free of non-ASCII source characters so nothing here depends on which charset the
+// compiler guesses for this file: the text under test is spelled with \u escapes, and the
+// expectations with the UTF-8 bytes those characters must produce.
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include <common/odbc_common.h>
+#include <odbc/odbc_handles.h>
+
+#include "mock_odbc_api.h"
+
+namespace mssql::test {
+namespace {
+
+// Lay a string out the way a driver hands one back: the text, then the terminator.
+std::vector<SQLWCHAR> driver_buffer(const std::u16string& text, const size_t trailing_nuls = 1) {
+  std::vector<SQLWCHAR> buffer;
+  buffer.reserve(text.size() + trailing_nuls);
+  for (const auto unit : text) {
+    buffer.push_back(static_cast<SQLWCHAR>(unit));
+  }
+  buffer.insert(buffer.end(), trailing_nuls, 0);
+  return buffer;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------------------
+// 1. Narrowing
+// ---------------------------------------------------------------------------------------
+
+TEST(DiagnosticTextTest, AsciiMessageRoundTrips) {
+  const auto buffer = driver_buffer(u"Invalid object name 'dbo.missing'.");
+  EXPECT_EQ(odbcstr::swcvec2str(buffer, buffer.size()), "Invalid object name 'dbo.missing'.");
+}
+
+// The line from the report - "--lista producentow uzytkownika, wydajnosciowych,
+// podwladnych" with its Polish diacritics. Every one of those characters used to be
+// narrowed to its low byte, so the line arrived as
+// "--lista producent<U+FFFD>w u|ytkownika, wydajno[ciowych, podwBadnych".
+TEST(DiagnosticTextTest, NonAsciiIsNotNarrowedToItsLowByte) {
+  const auto buffer =
+      driver_buffer(u"--lista producent\u00F3w u\u017Cytkownika, "
+                    u"wydajno\u015Bciowych, podw\u0142adnych");
+  const auto expected =
+      "--lista producent\xC3\xB3"
+      "w u\xC5\xBCytkownika, wydajno\xC5\x9B"
+      "ciowych, podw\xC5\x82"
+      "adnych";
+  EXPECT_EQ(odbcstr::swcvec2str(buffer, buffer.size()), expected);
+}
+
+// The characters whose low byte is a control code - U+0105 -> 0x05, U+0107 -> 0x07 (BEL),
+// U+0119 -> 0x19 - which used to vanish rather than look wrong. That is the worse half of
+// the bug: a word that simply loses a letter reads as a typo in somebody's procedure
+// rather than as driver damage.
+TEST(DiagnosticTextTest, CharactersWithControlCodeLowBytesSurvive) {
+  const auto buffer = driver_buffer(u"\u0105\u0107\u0119");
+  EXPECT_EQ(odbcstr::swcvec2str(buffer, buffer.size()), "\xC4\x85\xC4\x87\xC4\x99");
+}
+
+TEST(DiagnosticTextTest, SupplementaryPlaneCharacterIsRecombined) {
+  const auto buffer = driver_buffer(u"emoji \U0001F600 done");
+  EXPECT_EQ(odbcstr::swcvec2str(buffer, buffer.size()), "emoji \xF0\x9F\x98\x80 done");
+}
+
+// A lone surrogate cannot be encoded. It must not corrupt or end the rest of the line.
+TEST(DiagnosticTextTest, LoneSurrogateBecomesReplacementCharacter) {
+  const std::vector<SQLWCHAR> buffer{u'a', 0xD800, u'b', 0};
+  EXPECT_EQ(odbcstr::swcvec2str(buffer, buffer.size()),
+            "a\xEF\xBF\xBD"
+            "b");
+}
+
+// ---------------------------------------------------------------------------------------
+// 2. NUL handling
+// ---------------------------------------------------------------------------------------
+
+// `print N'PRZED' + nchar(0x0100) + N'PO'` used to arrive as "PRZED": U+0100 narrowed to
+// 0x00 and the string was then built from a NUL-terminated buffer.
+TEST(DiagnosticTextTest, CodeUnitWithZeroLowByteDoesNotEndTheMessage) {
+  const auto buffer = driver_buffer(u"PRZED\u0100PO");
+  EXPECT_EQ(odbcstr::swcvec2str(buffer, buffer.size()), "PRZED\xC4\x80PO");
+}
+
+// Trailing NULs must go: two callers pass the *buffer* size rather than a string length
+// and rely on the terminator.
+TEST(DiagnosticTextTest, TrailingNulPaddingIsDropped) {
+  const auto buffer = driver_buffer(u"42000");  // an SQLSTATE in its fixed six-unit buffer
+  ASSERT_EQ(buffer.size(), 6u);
+  EXPECT_EQ(odbcstr::swcvec2str(buffer, buffer.size()), "42000");
+
+  const std::vector<SQLWCHAR> padded{u'4', u'2', u'0', u'0', u'0', 0, 0, 0};
+  EXPECT_EQ(odbcstr::swcvec2str(padded, padded.size()), "42000");
+}
+
+// An *embedded* NUL is a legitimate character in a message and must not take the tail with
+// it. Note read_errors then hands the message to OdbcError as a const char*, so a genuine
+// U+0000 is still cut before it reaches JavaScript; this covers the conversion itself.
+TEST(DiagnosticTextTest, EmbeddedNulKeepsTheTail) {
+  const std::vector<SQLWCHAR> buffer{u'A', 0, u'B', 0};
+  EXPECT_EQ(odbcstr::swcvec2str(buffer, buffer.size()), std::string("A\0B", 3));
+}
+
+TEST(DiagnosticTextTest, EmptyAndAllNulBuffers) {
+  const std::vector<SQLWCHAR> empty;
+  EXPECT_EQ(odbcstr::swcvec2str(empty, 0), "");
+
+  const std::vector<SQLWCHAR> nuls{0, 0, 0};
+  EXPECT_EQ(odbcstr::swcvec2str(nuls, nuls.size()), "");
+}
+
+// ---------------------------------------------------------------------------------------
+// 3. Lengths that overrun the buffer
+// ---------------------------------------------------------------------------------------
+
+// SQLGetDiagRecW reports the length available, so callers can hand swcvec2str a length
+// past the end of the buffer.
+TEST(DiagnosticTextTest, LengthPastTheEndOfTheBufferIsClamped) {
+  const auto buffer = driver_buffer(u"short");
+  EXPECT_EQ(odbcstr::swcvec2str(buffer, 10 * 1024), "short");
+}
+
+// trim derived its length from capacity(), which a vector is free to make larger than
+// size() - so it could read past the elements that exist.
+TEST(DiagnosticTextTest, TrimClampsToSizeNotCapacity) {
+  std::vector<SQLWCHAR> buffer;
+  buffer.reserve(1024);
+  for (const auto unit : std::u16string(u"short")) {
+    buffer.push_back(static_cast<SQLWCHAR>(unit));
+  }
+  buffer.push_back(0);
+  ASSERT_GT(buffer.capacity(), buffer.size());
+  EXPECT_EQ(odbcstr::trim(buffer, 900), "short");
+}
+
+// ---------------------------------------------------------------------------------------
+// 4. read_errors and the 10239-character ceiling
+// ---------------------------------------------------------------------------------------
+
+namespace {
+
+using ::testing::_;
+using ::testing::Return;
+
+// `print cast(substring(@sql, 1, 16000) as ntext)` is the documented way around PRINT's
+// own 4000/8000 limit, so a diagnostic record longer than 10240 characters is ordinary.
+constexpr size_t kLongMessageChars = 16005;  // 16000 'x' plus "|END|"
+
+std::u16string long_message() {
+  return std::u16string(16000, u'x') + u"|END|";
+}
+
+// Stand in for a driver holding one record: write what fits, terminate it, and report the
+// full length available the way SQLGetDiagRecW does.
+SQLRETURN serve_record(const std::u16string& text,
+                       SQLWCHAR* sql_state,
+                       SQLINTEGER* native_error,
+                       SQLWCHAR* message,
+                       const SQLSMALLINT buffer_length,
+                       SQLSMALLINT* text_length) {
+  const std::u16string state = u"01000";
+  for (size_t i = 0; i < state.size(); ++i) {
+    sql_state[i] = static_cast<SQLWCHAR>(state[i]);
+  }
+  sql_state[state.size()] = 0;
+  *native_error = 0;
+  *text_length = static_cast<SQLSMALLINT>(text.size());
+
+  if (buffer_length <= 0) {
+    return SQL_SUCCESS_WITH_INFO;
+  }
+  const size_t writable = std::min(static_cast<size_t>(buffer_length) - 1, text.size());
+  for (size_t i = 0; i < writable; ++i) {
+    message[i] = static_cast<SQLWCHAR>(text[i]);
+  }
+  message[writable] = 0;
+  return writable < text.size() ? SQL_SUCCESS_WITH_INFO : SQL_SUCCESS;
+}
+
+}  // namespace
+
+TEST(ReadErrorsTest, ShortMessageIsReadWhole) {
+  const auto api = std::make_shared<MockOdbcApi>();
+  const std::u16string text = u"Changed database context to 'node'.";
+
+  EXPECT_CALL(*api, SQLGetDiagRecW(_, _, 1, _, _, _, _, _))
+      .WillOnce([&text](SQLSMALLINT,
+                        SQLHANDLE,
+                        SQLSMALLINT,
+                        SQLWCHAR* sql_state,
+                        SQLINTEGER* native_error,
+                        SQLWCHAR* message,
+                        SQLSMALLINT buffer_length,
+                        SQLSMALLINT* text_length) {
+        return serve_record(text, sql_state, native_error, message, buffer_length, text_length);
+      });
+  EXPECT_CALL(*api, SQLGetDiagRecW(_, _, 2, _, _, _, _, _)).WillOnce(Return(SQL_NO_DATA));
+  EXPECT_CALL(*api, SQLGetDiagField(_, _, _, _, _, _, _)).WillRepeatedly(Return(SQL_SUCCESS));
+
+  OdbcStatementHandleImpl handle;
+  auto errors = std::make_shared<std::vector<std::shared_ptr<OdbcError>>>();
+  handle.read_errors(api, errors);
+
+  ASSERT_EQ(errors->size(), 1u);
+  EXPECT_EQ(errors->at(0)->message, "Changed database context to 'node'.");
+  EXPECT_EQ(errors->at(0)->sqlstate, "01000");
+}
+
+// The reported ceiling: 10239 characters arrived and the rest was gone with no error.
+TEST(ReadErrorsTest, MessageLongerThanTheBufferIsNotTruncated) {
+  const auto api = std::make_shared<MockOdbcApi>();
+  const auto text = long_message();
+  ASSERT_EQ(text.size(), kLongMessageChars);
+
+  EXPECT_CALL(*api, SQLGetDiagRecW(_, _, 1, _, _, _, _, _))
+      .Times(::testing::AtLeast(1))
+      .WillRepeatedly([&text](SQLSMALLINT,
+                              SQLHANDLE,
+                              SQLSMALLINT,
+                              SQLWCHAR* sql_state,
+                              SQLINTEGER* native_error,
+                              SQLWCHAR* message,
+                              SQLSMALLINT buffer_length,
+                              SQLSMALLINT* text_length) {
+        return serve_record(text, sql_state, native_error, message, buffer_length, text_length);
+      });
+  EXPECT_CALL(*api, SQLGetDiagRecW(_, _, 2, _, _, _, _, _)).WillOnce(Return(SQL_NO_DATA));
+  EXPECT_CALL(*api, SQLGetDiagField(_, _, _, _, _, _, _)).WillRepeatedly(Return(SQL_SUCCESS));
+
+  OdbcStatementHandleImpl handle;
+  auto errors = std::make_shared<std::vector<std::shared_ptr<OdbcError>>>();
+  handle.read_errors(api, errors);
+
+  ASSERT_EQ(errors->size(), 1u);
+  const auto& message = errors->at(0)->message;
+  EXPECT_EQ(message.size(), kLongMessageChars);
+  ASSERT_GE(message.size(), 5u);
+  EXPECT_EQ(message.substr(message.size() - 5), "|END|");
+}
+
+}  // namespace mssql::test

--- a/test/diagnostic-text.test.js
+++ b/test/diagnostic-text.test.js
@@ -1,0 +1,84 @@
+'use strict'
+
+// Regression tests for issue #446 - PRINT / RAISERROR text arriving damaged.
+//
+// The diagnostic path used to keep only the low byte of each UTF-16 code unit, so U+017C
+// (z with dot) arrived as '|' and U+0142 (l with stroke) as 'B', characters whose low byte
+// was a control code vanished, a code unit whose low byte was 0x00 (U+0100) ended the
+// message, and any record longer than the 10 * 1024 unit buffer was cut to 10239
+// characters with no error. Result rows were never affected - only diagnostics.
+//
+// The text under test is written with \u escapes so these assertions do not depend on how
+// this file's own encoding survives a round trip through an editor or a patch.
+
+import { createRequire } from 'module'
+const require = createRequire(import.meta.url)
+const { TestEnv } = require('./env/test-env')
+const env = new TestEnv()
+const chai = require('chai')
+const expect = chai.expect
+
+const sql = require('../lib/sql')
+const { configureTestLogging } = require('./common/logging-helper')
+
+configureTestLogging(sql)
+
+describe('diagnostic-text', function () {
+  this.timeout(50000)
+
+  this.beforeEach(async function () {
+    await env.open()
+  })
+
+  this.afterEach(async function () {
+    await env.close()
+  })
+
+  // "--lista producentow uzytkownika, wydajnosciowych, podwladnych" with its diacritics.
+  // Used to arrive as "--lista producent<U+FFFD>w u|ytkownika, wydajno[ciowych, podwBadnych".
+  it('keeps non ascii characters in a print message', async function handler () {
+    const text = '--lista producent\u00F3w u\u017Cytkownika, wydajno\u015Bciowych, podw\u0142adnych'
+    const res = await env.theConnection.promises.query(`print N'${text}'`)
+    expect(res.info).to.have.lengthOf(1)
+    expect(res.info[0]).to.equal(text)
+  })
+
+  // U+0105, U+0107 and U+0119 narrow to 0x05, 0x07 (BEL) and 0x19, so these used to be
+  // dropped rather than replaced - a word that loses a letter reads as a typo in
+  // somebody's procedure rather than as driver damage.
+  it('keeps characters whose low byte is a control code', async function handler () {
+    const text = 'znak\u0105 znak\u0107 znak\u0119'
+    const res = await env.theConnection.promises.query(`print N'${text}'`)
+    expect(res.info[0]).to.equal(text)
+  })
+
+  // The low byte of U+0100 is 0x00, which used to terminate the message.
+  it('does not end a message at a code unit whose low byte is zero', async function handler () {
+    const res = await env.theConnection.promises.query("print N'PRZED' + nchar(0x0100) + N'PO'")
+    expect(res.info[0]).to.equal('PRZED\u0100PO')
+  })
+
+  // Longer than the 10 * 1024 unit buffer, and comfortably inside what the driver will
+  // hand over for one diagnostic record, so the whole message must arrive. This used to
+  // stop at 10239 characters, losing the tail out of the middle of a generated statement.
+  it('reads a print message longer than the diagnostic buffer', async function handler () {
+    const body = 'x'.repeat(12000)
+    const expected = `${body}|END|`
+    const res = await env.theConnection.promises.query(
+      "declare @long nvarchar(max) = replicate(cast(N'x' as nvarchar(max)), 12000); " +
+      "print cast(@long + N'|END|' as ntext)")
+    expect(res.info).to.have.lengthOf(1)
+    expect(res.info[0]).to.have.lengthOf(expected.length)
+    expect(res.info[0]).to.equal(expected)
+  })
+
+  it('keeps non ascii characters in a raiserror message', async function handler () {
+    const text = 'b\u0142\u0105d w procedurze'
+    try {
+      await env.theConnection.promises.query(`raiserror(N'${text}', 16, 1)`)
+      expect.fail('raiserror should have produced an error')
+    } catch (e) {
+      expect(e.message).to.contain(text)
+    }
+  })
+})


### PR DESCRIPTION
The three claims — all confirmed

1. Narrowing. cpp/include/common/odbc_common.h:150 did exactly what he says. Live output before the fix:
--lista producent<U+FFFD>w u|ytkownika, wydajno[ciowych, podwBadnych
ł→B, ż→|, ś→[, and ó's lone 0xF3 → U+FFFD. ąćę came through as \x05 \x07 \x19 — invisible, as he warned. His premise that UTF-8 is the right target checks out: js_object_mapper.cpp:387 hands the message to Napi::String::New, i.e. napi_create_string_utf8.

2. NUL truncation. print N'PRZED' + nchar(0x0100) + N'PO' arrived as PRZED. Worth noting the mechanism in his own repro isn't an embedded NUL — it's U+0100's low byte being 0x00. Both truncate, and the fix handles both.

3. The 10239 ceiling. Exact. My direct ODBC probe, on the real driver:
replicate=16000 (PRINTed 16005 chars)
buffer 10240 (old)     rc=1(WITH_INFO)  msg_len=16056  written=10239
buffer 32767 (API max) rc=0             msg_len=16056  written=16056
The driver reports 16056 available and writes 10239; the old code ignored the return.

One correction to the report

His expected 16005 isn't attainable. Driver 17/18 caps a single diagnostic record at 16056 characters — the 54-char [Microsoft][ODBC Driver 17...] prefix plus 16002. msg_len is 16056 whether the server PRINTs 16005, 20005 or 40005 characters, at any buffer size. So after his fix you get 16056, i.e. everything available; the residual 3 characters are the driver's, not recoverable.

His 32767 clamp also turns out to be necessary, not just tidy: BufferLength=40000 overflows the SQLSMALLINT and the driver returns SQL_ERROR with nothing written.

Fix review

Applies cleanly to master with git apply, compiles, clang-format clean, 733 passing / 0 failing on the full JS suite. It also closes a latent overrun — msg.capacity() was being passed as BufferLength. Three minor notes:

- The new doc comment says trim derives its length from capacity(), but the same patch changes trim to size() — stale on arrival.
- The embedded-NUL preservation can't reach JS: read_errors builds OdbcError from c_msg.c_str() (odbc_handles.h:150), so a genuine U+0000 is still cut there. Doesn't affect the reported case.
- At msg_len == 32767 exactly you still lose one character to the terminator. Unavoidable through this API.

Regression tests added

- test/cpp/unit/diagnostic_text_test.cpp — 13 gtest cases, no server or driver needed. 7 fail before the patch, 13 pass after.
- test/diagnostic-text.test.js — 5 mocha cases end-to-end. I reverted the patch, rebuilt, and confirmed all 5 fail (10185 = 10239 minus the stripped prefix), then restored and confirmed all 5 pass. Pinned at 12000 characters to stay clear of the driver ceiling.